### PR TITLE
chore: fix lockfile and major changeset

### DIFF
--- a/.changeset/seven-owls-tickle.md
+++ b/.changeset/seven-owls-tickle.md
@@ -1,5 +1,5 @@
 ---
-'@flatfile/plugin-xlsx-parser': minor
+'@flatfile/plugin-xlsx-parser': major
 ---
 
 Initial release of xlsx plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,7 +137,7 @@ importers:
 
   plugins/xlsx-parser:
     specifiers:
-      '@flatfile/api': ^1.4.5
+      '@flatfile/api': ^1.4.8
       '@flatfile/hooks': ^1.3.0
       '@flatfile/listener': ^0.1.2
       '@types/jest': ^29.5.0


### PR DESCRIPTION
Fix `pnpm-lock.yaml` to reference latest `@flatfile/api`