### PR TITLE
feat: add event to RecordHook handler()

### DIFF
--- a/.changeset/polite-points-dress.md
+++ b/.changeset/polite-points-dress.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': patch
+---
+
+Add event to RecordHook Handler


### PR DESCRIPTION
### Adds `event` to `RecordHook` handler()


Here are 2 examples (mind the capitalization 😅):
In the `RecordHook` export:
```ts
  await RecordHook(event, async (record: FlatfileRecord, event: FlatfileEvent) => {
     ...
  })
```

In the `recordHook` plugin:
```ts
  listener.use(
    recordHook('sheetSlug', async (record: FlatfileRecord, event: FlatfileEvent) => {
     ...
    })
)
```