### PR TITLE
feat: export FlatfileRecord from RecordHookPlugin

### DIFF
--- a/.changeset/cold-houses-relate.md
+++ b/.changeset/cold-houses-relate.md
@@ -1,0 +1,5 @@
+---
+"@flatfile/plugin-record-hook": patch
+---
+
+Add FlatfileRecord as export

--- a/plugins/record-hook/src/index.ts
+++ b/plugins/record-hook/src/index.ts
@@ -1,15 +1,4 @@
-import { FlatfileListener, FlatfileEvent } from "@flatfile/listener";
-import { RecordHook } from "./RecordHook";
-import type { FlatfileRecord } from "@flatfile/hooks";
 export * from "./RecordHook";
+export * from "./record.hook.plugin";
 
-export const recordHook = (
-  sheetSlug: string,
-  callback: (record: FlatfileRecord, event?: FlatfileEvent) => {}
-) => {
-  return (client: FlatfileListener) => {
-    client.on("commit:created", { sheetSlug }, (event: FlatfileEvent) => {
-      return RecordHook(event, callback);
-    });
-  };
-};
+export { FlatfileRecord } from "@flatfile/hooks";

--- a/plugins/record-hook/src/record.hook.plugin.ts
+++ b/plugins/record-hook/src/record.hook.plugin.ts
@@ -1,0 +1,16 @@
+import { FlatfileListener, FlatfileEvent } from "@flatfile/listener";
+import { RecordHook } from "./RecordHook";
+import type { FlatfileRecord } from "@flatfile/hooks";
+
+export const recordHookPlugin = (
+  sheetSlug: string,
+  callback: (record: FlatfileRecord, event?: FlatfileEvent) => {}
+) => {
+  return (client: FlatfileListener) => {
+    client.on("commit:created", { sheetSlug }, (event: FlatfileEvent) => {
+      return RecordHook(event, callback);
+    });
+  };
+};
+
+export { recordHookPlugin as recordHook };


### PR DESCRIPTION
Adds export of `FlatfileRecord` and change plugin name
Changes name of the `recordHook` plugin to `recordHookPlugin` (with the fallback of `recordHook` for backwards compatibility)
