### PR TITLE
fix: move info to executing job

### DIFF
--- a/plugins/xlsx-extractor/src/abstract.extractor.ts
+++ b/plugins/xlsx-extractor/src/abstract.extractor.ts
@@ -51,7 +51,6 @@ export class AbstractExtractor {
         source: this.fileId,
         // TODO: This should be configurable
         managed: true,
-        info: "Waiting",
       });
 
       if (!res || !res.data) {

--- a/plugins/xlsx-extractor/src/excel.extractor.ts
+++ b/plugins/xlsx-extractor/src/excel.extractor.ts
@@ -1,7 +1,7 @@
-import * as XLSX from "xlsx";
-import { mapKeys, mapValues } from "remeda";
-import { AbstractExtractor, SheetCapture } from "./abstract.extractor";
 import type { Flatfile } from "@flatfile/api";
+import { mapKeys, mapValues } from "remeda";
+import * as XLSX from "xlsx";
+import { AbstractExtractor, SheetCapture } from "./abstract.extractor";
 
 export class ExcelExtractor extends AbstractExtractor {
   private readonly _options: {
@@ -80,6 +80,7 @@ export class ExcelExtractor extends AbstractExtractor {
       //set status for getFileBuffer()
       await this.api.jobs.update(job.id, {
         status: "executing",
+        info: 'Starting extraction'
       });
 
       await this.api.jobs.ack(job.id, {


### PR DESCRIPTION
Adding info to the execute call will prevent the loading spinner from showing up without any info