### PR TITLE
Accept empty cells for psv

### DIFF
--- a/.changeset/unlucky-peas-sit.md
+++ b/.changeset/unlucky-peas-sit.md
@@ -1,0 +1,5 @@
+---
+"@flatfile/plugin-psv-extractor": patch
+---
+
+fix to empty columns

--- a/package-lock.json
+++ b/package-lock.json
@@ -14580,7 +14580,7 @@
     },
     "plugins/psv-extractor": {
       "name": "@flatfile/plugin-psv-extractor",
-      "version": "1.0.0",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",
@@ -14622,7 +14622,7 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",

--- a/plugins/psv-extractor/src/psv.extractor.ts
+++ b/plugins/psv-extractor/src/psv.extractor.ts
@@ -35,6 +35,7 @@ export class PsvExtractor extends AbstractExtractor {
         {
           delimiter: "|",
           header: true,
+          skipEmptyLines: "greedy",
         }
       );
 


### PR DESCRIPTION
To handle empty cells, you can modify the papaparse configuration by setting the skipEmptyLines option to 'greedy'. This option tells papaparse to treat lines with missing values as if they contain empty values. 