### PR TITLE
feat: bulk record hook

### DIFF
--- a/.changeset/swift-rivers-whisper.md
+++ b/.changeset/swift-rivers-whisper.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': patch
+---
+
+Create bulkRecordHook plugin

--- a/.changeset/swift-rivers-whisper.md
+++ b/.changeset/swift-rivers-whisper.md
@@ -1,5 +1,5 @@
 ---
-'@flatfile/plugin-record-hook': patch
+'@flatfile/plugin-record-hook': major
 ---
 
 Create bulkRecordHook plugin

--- a/plugins/record-hook/src/async.batch.spec.ts
+++ b/plugins/record-hook/src/async.batch.spec.ts
@@ -1,0 +1,114 @@
+import { asyncBatch } from './async.batch'
+
+describe('asyncBatch', () => {
+  it('should split the array into chunks and call the callback for each chunk', async () => {
+    const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const callback = jest.fn((chunk: number[]) => {
+      return Promise.resolve(chunk.reduce((sum, num) => sum + num, 0))
+    })
+    const options = {
+      chunkSize: 3,
+      parallel: 2,
+    }
+
+    const results = await asyncBatch(arr, callback, options)
+
+    expect(callback).toHaveBeenCalledTimes(4)
+    expect(callback).toHaveBeenNthCalledWith(1, [1, 2, 3])
+    expect(callback).toHaveBeenNthCalledWith(2, [4, 5, 6])
+    expect(callback).toHaveBeenNthCalledWith(3, [7, 8, 9])
+    expect(callback).toHaveBeenNthCalledWith(4, [10])
+    expect(results).toEqual([6, 15, 24, 10])
+  })
+
+  it('should handle empty array', async () => {
+    const arr: number[] = []
+    const callback = jest.fn((chunk: number[]) => {
+      return Promise.resolve(chunk.reduce((sum, num) => sum + num, 0))
+    })
+    const options = {
+      chunkSize: 3,
+      parallel: 2,
+    }
+
+    const results = await asyncBatch(arr, callback, options)
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(results).toEqual([])
+  })
+
+  it('should handle array smaller than chunk size', async () => {
+    const arr = [1, 2]
+    const callback = jest.fn((chunk: number[]) => {
+      return Promise.resolve(chunk.reduce((sum, num) => sum + num, 0))
+    })
+    const options = {
+      chunkSize: 3,
+      parallel: 2,
+    }
+
+    const results = await asyncBatch(arr, callback, options)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith([1, 2])
+    expect(results).toEqual([3])
+  })
+
+  it('should handle array size equal to chunk size', async () => {
+    const arr = [1, 2, 3]
+    const callback = jest.fn((chunk: number[]) => {
+      return Promise.resolve(chunk.reduce((sum, num) => sum + num, 0))
+    })
+    const options = {
+      chunkSize: 3,
+      parallel: 2,
+    }
+
+    const results = await asyncBatch(arr, callback, options)
+
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenCalledWith([1, 2, 3])
+    expect(results).toEqual([6])
+  })
+
+  it('should handle parallel value greater than array size', async () => {
+    const arr = [1, 2, 3, 4, 5]
+    const callback = jest.fn((chunk: number[]) => {
+      return Promise.resolve(chunk.reduce((sum, num) => sum + num, 0))
+    })
+    const options = {
+      chunkSize: 2,
+      parallel: 10,
+    }
+
+    const results = await asyncBatch(arr, callback, options)
+
+    expect(callback).toHaveBeenCalledTimes(3)
+    expect(callback).toHaveBeenNthCalledWith(1, [1, 2])
+    expect(callback).toHaveBeenNthCalledWith(2, [3, 4])
+    expect(callback).toHaveBeenNthCalledWith(3, [5])
+    expect(results).toEqual([3, 7, 5])
+  })
+
+  it('should handle asynchronous callbacks', async () => {
+    const arr = [1, 2, 3]
+    const callback = jest.fn((chunk: number[]) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(chunk.reduce((sum, num) => sum + num, 0))
+        }, 1000)
+      })
+    })
+    const options = {
+      chunkSize: 2,
+      parallel: 2,
+    }
+
+    const results = await asyncBatch(arr, callback, options)
+
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenNthCalledWith(1, [1, 2])
+    expect(callback).toHaveBeenNthCalledWith(2, [3])
+    expect(results).toEqual([3, 3])
+  })
+})

--- a/plugins/record-hook/src/async.batch.ts
+++ b/plugins/record-hook/src/async.batch.ts
@@ -1,0 +1,56 @@
+export async function asyncBatch<T, R>(
+  arr: T[],
+  callback: (chunk: T[]) => Promise<R>,
+  options: { chunkSize?: number; parallel?: number } = {}
+): Promise<R[]> {
+  const { chunkSize, parallel } = { chunkSize: 1000, parallel: 1, ...options }
+  const results: R[] = []
+
+  // Split the array into chunks
+  const chunks: T[][] = []
+  for (let i = 0; i < arr.length; i += chunkSize) {
+    chunks.push(arr.slice(i, i + chunkSize))
+  }
+
+  // Create a helper function to process a chunk
+  async function processChunk(chunk: T[]): Promise<void> {
+    const result = await callback(chunk)
+    results.push(result)
+  }
+
+  // Execute the chunks in parallel
+  const promises: Promise<void>[] = []
+  let running = 0
+  let currentIndex = 0
+
+  function processNext(): void {
+    if (currentIndex >= chunks.length) {
+      // All chunks have been processed
+      return
+    }
+
+    const currentChunk = chunks[currentIndex]
+    const promise = processChunk(currentChunk).finally(() => {
+      running--
+      processNext() // Process next chunk
+    })
+
+    promises.push(promise)
+    currentIndex++
+    running++
+
+    if (running < parallel) {
+      processNext() // Process another chunk if available
+    }
+  }
+
+  // Start processing the chunks
+  for (let i = 0; i < parallel && i < chunks.length; i++) {
+    processNext()
+  }
+
+  // Wait for all promises to resolve
+  await Promise.all(promises)
+
+  return results
+}

--- a/plugins/record-hook/src/record.hook.plugin.ts
+++ b/plugins/record-hook/src/record.hook.plugin.ts
@@ -1,10 +1,13 @@
 import { FlatfileListener, FlatfileEvent } from '@flatfile/listener'
-import { RecordHook } from './RecordHook'
+import { BulkRecordHook, RecordHook } from './RecordHook'
 import type { FlatfileRecord } from '@flatfile/hooks'
 
 export const recordHookPlugin = (
   sheetSlug: string,
-  callback: (record: FlatfileRecord, event?: FlatfileEvent) => {}
+  callback: (
+    record: FlatfileRecord,
+    event?: FlatfileEvent
+  ) => any | Promise<any>
 ) => {
   return (client: FlatfileListener) => {
     client.on('commit:created', { sheetSlug }, (event: FlatfileEvent) => {
@@ -13,4 +16,21 @@ export const recordHookPlugin = (
   }
 }
 
-export { recordHookPlugin as recordHook }
+export const bulkRecordHookPlugin = (
+  sheetSlug: string,
+  callback: (
+    records: FlatfileRecord[],
+    event?: FlatfileEvent
+  ) => any | Promise<any>
+) => {
+  return (client: FlatfileListener) => {
+    client.on('commit:created', { sheetSlug }, (event: FlatfileEvent) => {
+      return BulkRecordHook(event, callback)
+    })
+  }
+}
+
+export {
+  recordHookPlugin as recordHook,
+  bulkRecordHookPlugin as bulkRecordHook,
+}

--- a/plugins/record-hook/src/record.hook.plugin.ts
+++ b/plugins/record-hook/src/record.hook.plugin.ts
@@ -21,7 +21,8 @@ export const bulkRecordHookPlugin = (
   callback: (
     records: FlatfileRecord[],
     event?: FlatfileEvent
-  ) => any | Promise<any>
+  ) => any | Promise<any>,
+  options: { chunkSize?: number; parallel?: number } = {}
 ) => {
   return (client: FlatfileListener) => {
     client.on('commit:created', { sheetSlug }, (event: FlatfileEvent) => {

--- a/plugins/record-hook/src/record.hook.plugin.ts
+++ b/plugins/record-hook/src/record.hook.plugin.ts
@@ -26,7 +26,7 @@ export const bulkRecordHookPlugin = (
 ) => {
   return (client: FlatfileListener) => {
     client.on('commit:created', { sheetSlug }, (event: FlatfileEvent) => {
-      return BulkRecordHook(event, callback)
+      return BulkRecordHook(event, callback, options)
     })
   }
 }


### PR DESCRIPTION
The `bulkRecordHook` function passes batches of records to the given `handler`.

Install:
```
npm i @flatfile/plugin-record-hook @flatfile/hooks
```

Default chunk size is 1,000 (same as commit:created)
Default parallel is 1. These will run in parallel.

Example usage:
```
import { FlatfileRecord } from '@flatfile/hooks'
import { bulkRecordHook } from '@flatfile/plugin-record-hook'

export default async function (listener) {
  listener.use(
    bulkRecordHook(
      'contacts',
      (records: FlatfileRecord[]) => {
        return records.map((r) => {
          const email = r.get('email') as string
          if (!email) {
            console.log('Email is required')
            r.addError('email', 'Email is required')
          }
          const validEmailAddress = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
          if (email !== null && !validEmailAddress.test(email)) {
            console.log('Invalid email address')
            r.addError('email', 'Invalid email address')
          }
          return r
        })
      },
      { chunkSize: 100, parallel: 2 }
    )
  )
}
```