### PR TITLE
monorepo fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,7 @@
         "typescript": "^5.0.4"
       },
       "engines": {
-        "node": ">=16 || >=18",
-        "pnpm": ">=7"
+        "node": ">=16"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -13840,12 +13839,12 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/listener": "^0.3.4",
-        "@flatfile/util-extractor": "0.2.0",
+        "@flatfile/util-extractor": "0.2.1",
         "papaparse": "^5.4.1",
         "remeda": "^1.14.0"
       },
@@ -13926,13 +13925,13 @@
     },
     "plugins/json-extractor": {
       "name": "@flatfile/plugin-json-extractor",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.10",
-        "@flatfile/util-extractor": "0.2.0",
+        "@flatfile/util-extractor": "0.2.1",
         "remeda": "^1.14.0"
       },
       "devDependencies": {
@@ -13961,11 +13960,11 @@
     },
     "plugins/psv-extractor": {
       "name": "@flatfile/plugin-psv-extractor",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
-        "@flatfile/plugin-delimiter-extractor": "^0.2.0"
+        "@flatfile/plugin-delimiter-extractor": "^0.3.0"
       },
       "engines": {
         "node": ">= 16"
@@ -13973,13 +13972,13 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.11",
-        "@flatfile/util-common": "^0.0.1"
+        "@flatfile/util-common": "^0.0.2"
       },
       "devDependencies": {
         "@flatfile/listener-driver-pubsub": "^1.0.0",
@@ -13996,11 +13995,11 @@
     },
     "plugins/tsv-extractor": {
       "name": "@flatfile/plugin-tsv-extractor",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
-        "@flatfile/plugin-delimiter-extractor": "^0.2.0"
+        "@flatfile/plugin-delimiter-extractor": "^0.3.0"
       },
       "engines": {
         "node": ">= 16"
@@ -14008,13 +14007,13 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.4",
-        "@flatfile/util-extractor": "0.2.0",
+        "@flatfile/util-extractor": "0.2.1",
         "remeda": "^1.14.0",
         "xlsx": "^0.18.5"
       },
@@ -14092,7 +14091,8 @@
       }
     },
     "utils/common": {
-      "version": "0.0.1",
+      "name": "@flatfile/util-common",
+      "version": "0.0.2",
       "license": "ISC",
       "engines": {
         "node": ">= 16"
@@ -14100,12 +14100,12 @@
     },
     "utils/extractor": {
       "name": "@flatfile/util-extractor",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/listener": "^0.3.4",
-        "@flatfile/util-common": "^0.0.1",
+        "@flatfile/util-common": "^0.0.2",
         "@flatfile/util-file-buffer": "0.0.2",
         "remeda": "^1.14.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "0.0.0",
   "description": "A library of open-source plugins for developers working with the Flatfile Platform.",
   "engines": {
-    "node": ">=16 || >=18",
-    "pnpm": ">=7"
+    "node": ">=16"
   },
   "workspaces": [
     "plugins/*",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "scripts": {
     "clean": "find ./ '(' -name 'node_modules' -o -name 'dist' -o -name '.turbo' ')' -type d -exec rm -rf {} +",
-    "test": "turbo test",
+    "test": "turbo test --concurrency=1",
     "build": "turbo build",
     "lint": "prettier --check **/*.ts",
     "changeset": "changeset",
@@ -29,7 +29,7 @@
     "typescript",
     "node.js"
   ],
-  "author": "Alex Hollenbeck",
+  "author": "Flatfile, Inc.",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/FlatFilers/flatfile-plugins/issues"

--- a/plugins/automap/package.json
+++ b/plugins/automap/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Flatfile",

--- a/plugins/delimiter-extractor/package.json
+++ b/plugins/delimiter-extractor/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Carl Brugger",

--- a/plugins/dxp-configure/package.json
+++ b/plugins/dxp-configure/package.json
@@ -21,7 +21,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --passWithNoTests"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "David Boskovic",

--- a/plugins/export-worbook/package.json
+++ b/plugins/export-worbook/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Flatfile, Inc.",

--- a/plugins/json-extractor/package.json
+++ b/plugins/json-extractor/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Carl Brugger",

--- a/plugins/psv-extractor/package.json
+++ b/plugins/psv-extractor/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Ashley Mulligan",

--- a/plugins/record-hook/package.json
+++ b/plugins/record-hook/package.json
@@ -21,7 +21,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Alex Hollenbeck",

--- a/plugins/tsv-extractor/package.json
+++ b/plugins/tsv-extractor/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Ashley Mulligan",

--- a/plugins/xlsx-extractor/package.json
+++ b/plugins/xlsx-extractor/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "David Boskovic",

--- a/plugins/xml-extractor/package.json
+++ b/plugins/xml-extractor/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "David Boskovic",

--- a/plugins/zip-extractor/package.json
+++ b/plugins/zip-extractor/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "keywords": [],
   "author": "Carl Brugger",

--- a/support/common-utils/package.json
+++ b/support/common-utils/package.json
@@ -20,7 +20,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "repository": {
     "type": "git",

--- a/utils/common/package.json
+++ b/utils/common/package.json
@@ -15,7 +15,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "repository": {
     "type": "git",

--- a/utils/extractor/package.json
+++ b/utils/extractor/package.json
@@ -15,7 +15,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
   "repository": {
     "type": "git",

--- a/utils/file-buffer/package.json
+++ b/utils/file-buffer/package.json
@@ -16,7 +16,7 @@
     "build": "parcel build",
     "dev": "parcel watch",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest ./**/*.spec.ts --config=../../jest.config.js  --passWithNoTests"
+    "test": "jest --passWithNoTests"
   },
   "keywords": [],
   "author": "David Boskovic",


### PR DESCRIPTION
# Inspiration

The following changes should fix the "flakiness" of the monorepo in CI.

- Update out-of-sync deps (published versions w/ what is in the lock file)
  -  `@flatfile/plugin-delimiter-extractor`
  - `@flatfile/util-extractor`
  - `@flatfile/json-extractor`
  - `@flatfile/util-common`
  - `@flatfile/plugin-record-hook`
  - `@flatfile/plugin-xlsx-extractor`
- Force Turbo (`--concurrency=1`) and Jest (`--runInBand`) to run tests sequentially so they don't step on top of each other 

Note: this is a temporary fix and long term we should look at the Turbo cache configuration