### PR TITLE
chore: cleanup

### DIFF
--- a/.changeset/perfect-pens-shake.md
+++ b/.changeset/perfect-pens-shake.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/plugin-psv-extractor': patch
+'@flatfile/plugin-tsv-extractor': patch
+---
+
+Remove unsupported parameter

--- a/plugins/autocast/package.json
+++ b/plugins/autocast/package.json
@@ -4,7 +4,7 @@
   "description": "A plugin for automatically casting values in Flatfile.",
   "registryMetadata": {
     "status": "Coming soon",
-    "cagegory": "transform"
+    "category": "transform"
   },
   "keywords": [],
   "author": "Alex Hollenbeck",

--- a/plugins/delimiter-extractor/src/parser.spec.ts
+++ b/plugins/delimiter-extractor/src/parser.spec.ts
@@ -39,7 +39,7 @@ describe('parser', () => {
       },
     })
   })
-  test('hasHeaders', () => {
+  it('has headers', () => {
     const headers = parseBuffer(psvBuffer, { delimiter: '|' }).Sheet1.headers
     expect(headers).toEqual(['Code', 'Details', 'BranchName', 'Tenant'])
   })

--- a/plugins/json-extractor/src/parser.spec.ts
+++ b/plugins/json-extractor/src/parser.spec.ts
@@ -32,7 +32,7 @@ describe('parser', function () {
       },
     })
   })
-  test('hasHeaders', () => {
+  it('has headers', () => {
     const headers = parseBuffer(buffer).Sheet1.headers
     expect(headers).toEqual(['First Name', 'Last Name', 'Email'])
   })

--- a/plugins/psv-extractor/src/index.ts
+++ b/plugins/psv-extractor/src/index.ts
@@ -3,7 +3,6 @@ import { DelimiterExtractor } from '@flatfile/plugin-delimiter-extractor'
 
 export const PSVExtractor = (options?: {
   dynamicTyping?: boolean
-  hasHeader?: boolean
   skipEmptyLines?: boolean | 'greedy'
   transform?: (value: any) => Flatfile.CellValueUnion
 }) => {

--- a/plugins/tsv-extractor/src/index.ts
+++ b/plugins/tsv-extractor/src/index.ts
@@ -3,7 +3,6 @@ import { DelimiterExtractor } from '@flatfile/plugin-delimiter-extractor'
 
 export const TSVExtractor = (options?: {
   dynamicTyping?: boolean
-  hasHeader?: boolean
   skipEmptyLines?: boolean | 'greedy'
   transform?: (value: any) => Flatfile.CellValueUnion
 }) => {


### PR DESCRIPTION
This PR does a couple things:
- Removes the `hasHeader` parameter from the PSV & TSV extractors. This parameter was introduced in https://github.com/FlatFilers/flatfile-plugins/pull/150 and replaced with header row auto-detection in https://github.com/FlatFilers/flatfile-plugins/pull/158.
- Fixes a typo in the `autocast/package.json`.
- Changes test descriptions to better describe the purpose.