### PR TITLE
feat:refactor XMLExtractor to use `@flatfile/util-extractor` package

### DIFF
--- a/.changeset/brown-buckets-drum.md
+++ b/.changeset/brown-buckets-drum.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-xml-extractor': minor
+---
+
+Refactor XMLExtractor to use @flatfile/util-extractor package

--- a/package-lock.json
+++ b/package-lock.json
@@ -13788,6 +13788,7 @@
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/listener": "^0.3.11",
+        "@flatfile/util-extractor": "0.2.1",
         "@flatfile/util-file-buffer": "0.0.2",
         "xml-json-format": "^1.0.8"
       },

--- a/plugins/xml-extractor/package.json
+++ b/plugins/xml-extractor/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@flatfile/api": "^1.5.13",
     "@flatfile/listener": "^0.3.11",
+    "@flatfile/util-extractor": "0.2.1",
     "@flatfile/util-file-buffer": "0.0.2",
     "xml-json-format": "^1.0.8"
   }

--- a/plugins/xml-extractor/src/index.ts
+++ b/plugins/xml-extractor/src/index.ts
@@ -1,69 +1,10 @@
-import type { FlatfileListener } from "@flatfile/listener";
-import { fileBuffer } from "@flatfile/util-file-buffer";
-import { flatToValues, schemaFromObjectList, xmlToJson } from "./parser";
-import api, { Flatfile } from "@flatfile/api";
+import { parseBuffer } from './parser'
+import { Extractor } from '@flatfile/util-extractor'
 
-export const XMLExtractor = (opts?: {
-  separator?: string;
-  attributePrefix?: string;
-  transform?: (row: Record<string, any>) => Record<string, any>;
+export const XMLExtractor = (options?: {
+  separator?: string
+  attributePrefix?: string
+  transform?: (row: Record<string, any>) => Record<string, any>
 }) => {
-  return (handler: FlatfileListener) => {
-    handler.use(
-      fileBuffer(".xml", async (file, buffer, event) => {
-        const job = await api.jobs.create({
-          type: "file",
-          operation: "extract",
-          status: "ready",
-          source: event.context.fileId,
-        });
-        try {
-          const json = xmlToJson(buffer.toString()).map(
-            opts?.transform || ((x) => x)
-          );
-          const schema = schemaFromObjectList(json);
-          const workbook = await createWorkbook(
-            event.context.environmentId,
-            file,
-            file.name,
-            schema
-          );
-          await api.records.insert(workbook.sheets![0].id, flatToValues(json));
-          await api.files.update(file.id, {
-            workbookId: workbook.id,
-          });
-          await api.jobs.update(job.data.id, {
-            status: "complete",
-          });
-          console.log(workbook);
-        } catch (e) {
-          console.log(`error ${e}`);
-          await api.jobs.update(job.data.id, {
-            status: "failed",
-          });
-        }
-      })
-    );
-  };
-};
-
-async function createWorkbook(
-  environmentId: string,
-  file: Flatfile.File_,
-  filename: string,
-  fields: Array<{ key: string; type: "string" }>
-): Promise<Flatfile.Workbook> {
-  const workbook = await api.workbooks.create({
-    name: "[file] " + filename,
-    sheets: [
-      {
-        name: "Default",
-        fields,
-      },
-    ],
-    spaceId: file.spaceId,
-    labels: ["file"],
-    environmentId,
-  });
-  return workbook.data;
+  return Extractor('.xml', parseBuffer, options)
 }

--- a/plugins/xml-extractor/src/parser.spec.ts
+++ b/plugins/xml-extractor/src/parser.spec.ts
@@ -1,4 +1,4 @@
-import { findRoot, schemaFromObjectList, xmlToJson } from './parser'
+import { findRoot, headersFromObjectList, xmlToJson } from './parser'
 
 const XML = `<?xml version="1.0" encoding="UTF-8"?>
 <root>
@@ -75,33 +75,15 @@ describe('parser', function () {
     })
   })
 
-  test('schemaFromObjectList', function () {
+  test('headersFromObjectList', function () {
     const json = xmlToJson(XML)
-    expect(schemaFromObjectList(json)).toEqual([
-      {
-        key: 'street',
-        type: 'string',
-      },
-      {
-        key: 'country/name',
-        type: 'string',
-      },
-      {
-        key: 'country/iso',
-        type: 'string',
-      },
-      {
-        key: 'zip',
-        type: 'string',
-      },
-      {
-        key: 'zip#format',
-        type: 'string',
-      },
-      {
-        key: '#active',
-        type: 'string',
-      },
+    expect(headersFromObjectList(json)).toEqual([
+      'street',
+      'country/name',
+      'country/iso',
+      'zip',
+      'zip#format',
+      '#active',
     ])
   })
 


### PR DESCRIPTION
This PR refactors the `XMLExtractor` to use the `@flatfile/util-extractor` package. Using the utility extractor package resolves a job completion bug in the XMLExtractor and increases the maintainability of package code through DRYing.

