### PR TITLE
fix:XMLExtractor parser

### DIFF
--- a/.changeset/gorgeous-rules-end.md
+++ b/.changeset/gorgeous-rules-end.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-xml-extractor': minor
+---
+
+Fixes bug introduced in PR #172

--- a/package-lock.json
+++ b/package-lock.json
@@ -13604,7 +13604,7 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
@@ -13700,11 +13700,11 @@
     },
     "plugins/psv-extractor": {
       "name": "@flatfile/plugin-psv-extractor",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
-        "@flatfile/plugin-delimiter-extractor": "^0.3.0"
+        "@flatfile/plugin-delimiter-extractor": "^0.4.0"
       },
       "engines": {
         "node": ">= 16"
@@ -13735,11 +13735,11 @@
     },
     "plugins/tsv-extractor": {
       "name": "@flatfile/plugin-tsv-extractor",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
-        "@flatfile/plugin-delimiter-extractor": "^0.3.0"
+        "@flatfile/plugin-delimiter-extractor": "^0.4.0"
       },
       "engines": {
         "node": ">= 16"
@@ -13747,7 +13747,7 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",
@@ -13783,13 +13783,14 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/listener": "^0.3.11",
         "@flatfile/util-extractor": "0.2.1",
         "@flatfile/util-file-buffer": "0.0.2",
+        "remeda": "^1.24.0",
         "xml-json-format": "^1.0.8"
       },
       "engines": {

--- a/plugins/delimiter-extractor/README.md
+++ b/plugins/delimiter-extractor/README.md
@@ -1,4 +1,4 @@
-# @flatfile/plugin-delimiter-extractor"
+# @flatfile/plugin-delimiter-extractor
 
 This plugin parses a delimited file and extracts it into Flatfile.
 

--- a/plugins/xlsx-extractor/README.md
+++ b/plugins/xlsx-extractor/README.md
@@ -1,4 +1,4 @@
-# @flatfile/plugin-xlsx-extractor"
+# @flatfile/plugin-xlsx-extractor
 
 This package parses all Sheets in an XLSX file and extracts them into Flatfile.
 

--- a/plugins/xml-extractor/package.json
+++ b/plugins/xml-extractor/package.json
@@ -31,6 +31,7 @@
     "@flatfile/listener": "^0.3.11",
     "@flatfile/util-extractor": "0.2.1",
     "@flatfile/util-file-buffer": "0.0.2",
+    "remeda": "^1.24.0",
     "xml-json-format": "^1.0.8"
   }
 }

--- a/plugins/xml-extractor/src/parser.spec.ts
+++ b/plugins/xml-extractor/src/parser.spec.ts
@@ -1,4 +1,9 @@
-import { findRoot, headersFromObjectList, xmlToJson } from './parser'
+import {
+  parseBuffer,
+  findRoot,
+  headersFromObjectList,
+  xmlToJson,
+} from './parser'
 
 const XML = `<?xml version="1.0" encoding="UTF-8"?>
 <root>
@@ -37,6 +42,28 @@ const XMLWithOneItem = `<?xml version="1.0" encoding="UTF-8"?>
   </addresses>
 </root>
 `
+
+const XMLWithDupHeader = `<?xml version="1.0" encoding="UTF-8"?>
+<root>
+  <people>
+    <person>
+      <firstName>Tony</firstName>
+      <lastName>Lamb</lastName>
+      <email>me@opbaj.tp</email>
+    </person>
+    <person>
+      <firstName>Christian</firstName>
+      <lastName>Ramos</lastName>
+      <email>uw@ag.tg</email>
+    </person>
+    <person>
+      <firstName>Frederick</firstName>
+      <lastName>Boyd</lastName>
+      <email>kempur@ascebec.gs</email>
+      <email>wug@dejdipfo.is</email>
+    </person>
+  </people>
+</root>`
 
 describe('parser', function () {
   describe('xmlToJson', function () {
@@ -95,6 +122,35 @@ describe('parser', function () {
     })
     test('works with no declaration', () => {
       expect(findRoot({ red: { blue: 'green' } })).toEqual([{ blue: 'green' }])
+    })
+  })
+
+  describe('parser', () => {
+    test('test duplicate header', () => {
+      parseBuffer(Buffer.from(XMLWithDupHeader)) //?
+      expect(parseBuffer(Buffer.from(XMLWithDupHeader))).toEqual({
+        Sheet1: {
+          headers: ['firstName', 'lastName', 'email', 'email/0', 'email/1'],
+          data: [
+            {
+              firstName: { value: 'Tony' },
+              lastName: { value: 'Lamb' },
+              email: { value: 'me@opbaj.tp' },
+            },
+            {
+              firstName: { value: 'Christian' },
+              lastName: { value: 'Ramos' },
+              email: { value: 'uw@ag.tg' },
+            },
+            {
+              firstName: { value: 'Frederick' },
+              lastName: { value: 'Boyd' },
+              'email/0': { value: 'kempur@ascebec.gs' },
+              'email/1': { value: 'wug@dejdipfo.is' },
+            },
+          ],
+        },
+      })
     })
   })
 })

--- a/plugins/xml-extractor/src/parser.spec.ts
+++ b/plugins/xml-extractor/src/parser.spec.ts
@@ -127,7 +127,6 @@ describe('parser', function () {
 
   describe('parser', () => {
     test('test duplicate header', () => {
-      parseBuffer(Buffer.from(XMLWithDupHeader)) //?
       expect(parseBuffer(Buffer.from(XMLWithDupHeader))).toEqual({
         Sheet1: {
           headers: ['firstName', 'lastName', 'email', 'email/0', 'email/1'],

--- a/plugins/xml-extractor/src/parser.ts
+++ b/plugins/xml-extractor/src/parser.ts
@@ -1,5 +1,6 @@
 import toJSON from 'xml-json-format'
 import { WorkbookCapture } from '@flatfile/util-extractor'
+import { mapValues } from 'remeda'
 
 export function parseBuffer(
   buffer: Buffer,
@@ -10,14 +11,16 @@ export function parseBuffer(
   }
 ): WorkbookCapture {
   const transform = options?.transform || ((value) => value)
-  const data = xmlToJson(buffer.toString()).map(transform)
+  const data = xmlToJson(buffer.toString())
   const headers = headersFromObjectList(data)
 
   const sheetName = 'Sheet1'
   return {
     [sheetName]: {
       headers,
-      data,
+      data: data.map((row) => {
+        return mapValues(transform(row), (value) => ({ value }))
+      }),
     },
   } as WorkbookCapture
 }


### PR DESCRIPTION
Fixes bug introduced in https://github.com/FlatFilers/flatfile-plugins/pull/172 where values were not being pass in object. This PR also adds a test for `parseBuffer()`

Previous:
```
data: [
            {
              firstName: 'Tony',
              lastName: 'Lamb',
              email: 'me@opbaj.tp',
            },
]
```

Fixed:
```
data: [
            {
              firstName: { value: 'Tony' },
              lastName: { value: 'Lamb' },
              email: { value: 'me@opbaj.tp' },
            },
]
```