### PR TITLE
fix: exclude unwanted dir

### DIFF
--- a/.changeset/sweet-spoons-camp.md
+++ b/.changeset/sweet-spoons-camp.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-zip-extractor': patch
+---
+
+Exclude \_\_MACOSX

--- a/package-lock.json
+++ b/package-lock.json
@@ -13722,7 +13722,7 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",

--- a/plugins/zip-extractor/src/index.ts
+++ b/plugins/zip-extractor/src/index.ts
@@ -28,7 +28,7 @@ export const ZipExtractor = () => {
             progress: 50,
             info: 'Uploading files',
           })
-          zipEntries.forEach(async (zipEntry) => {
+          const uploadPromises = zipEntries.map(async (zipEntry) => {
             if (
               !zipEntry.entryName.startsWith('__MACOSX') &&
               !zipEntry.entryName.startsWith('.') &&
@@ -41,16 +41,16 @@ export const ZipExtractor = () => {
                 false,
                 true
               )
-
               const filePath = path.join(__dirname, '../', zipEntry.name)
               const stream = fs.createReadStream(filePath)
               await api.files.upload(stream, {
                 spaceId,
                 environmentId,
               })
-              fs.unlinkSync(filePath)
+              await fs.promises.unlink(filePath)
             }
           })
+          await Promise.all(uploadPromises)
           await api.jobs.complete(job.data.id, {
             info: 'Extraction complete',
           })

--- a/plugins/zip-extractor/src/index.ts
+++ b/plugins/zip-extractor/src/index.ts
@@ -30,6 +30,7 @@ export const ZipExtractor = () => {
           })
           zipEntries.forEach(async (zipEntry) => {
             if (
+              !zipEntry.entryName.startsWith('__MACOSX') &&
               !zipEntry.entryName.startsWith('.') &&
               !zipEntry.entryName.match('.DS_Store') &&
               !zipEntry.isDirectory

--- a/plugins/zip-extractor/src/index.ts
+++ b/plugins/zip-extractor/src/index.ts
@@ -30,9 +30,8 @@ export const ZipExtractor = () => {
           })
           const uploadPromises = zipEntries.map(async (zipEntry) => {
             if (
+              !zipEntry.name.startsWith('.') &&
               !zipEntry.entryName.startsWith('__MACOSX') &&
-              !zipEntry.entryName.startsWith('.') &&
-              !zipEntry.entryName.match('.DS_Store') &&
               !zipEntry.isDirectory
             ) {
               zip.extractEntryTo(


### PR DESCRIPTION
This PR excludes the `__MACOSX` directory from being uploaded to Flatfile. Fixes #177.