### PR TITLE
feat: add configurable batch options

### DIFF
--- a/.changeset/selfish-gorillas-clap.md
+++ b/.changeset/selfish-gorillas-clap.md
@@ -1,0 +1,11 @@
+---
+'@flatfile/plugin-delimiter-extractor': minor
+'@flatfile/plugin-json-extractor': minor
+'@flatfile/plugin-xlsx-extractor': minor
+'@flatfile/plugin-psv-extractor': minor
+'@flatfile/plugin-tsv-extractor': minor
+'@flatfile/plugin-xml-extractor': minor
+'@flatfile/util-extractor': minor
+---
+
+Add configurable batch options

--- a/plugins/delimiter-extractor/src/index.ts
+++ b/plugins/delimiter-extractor/src/index.ts
@@ -9,6 +9,8 @@ export const DelimiterExtractor = (
     dynamicTyping?: boolean
     skipEmptyLines?: boolean | 'greedy'
     transform?: (value: any) => Flatfile.CellValueUnion
+    chunkSize?: number
+    parallel?: number
   }
 ) => {
   return Extractor(fileExt, parseBuffer, options)

--- a/plugins/json-extractor/src/index.ts
+++ b/plugins/json-extractor/src/index.ts
@@ -1,8 +1,11 @@
 import { parseBuffer } from './parser'
 import { Extractor } from '@flatfile/util-extractor'
 
-export const JSONExtractor = () => {
-  return Extractor('.json', parseBuffer)
+export const JSONExtractor = (options: {
+  chunkSize?: number
+  parallel?: number
+}) => {
+  return Extractor('.json', parseBuffer, options)
 }
 
 /*

--- a/plugins/json-extractor/src/index.ts
+++ b/plugins/json-extractor/src/index.ts
@@ -1,7 +1,7 @@
 import { parseBuffer } from './parser'
 import { Extractor } from '@flatfile/util-extractor'
 
-export const JSONExtractor = (options: {
+export const JSONExtractor = (options?: {
   chunkSize?: number
   parallel?: number
 }) => {

--- a/plugins/psv-extractor/src/index.ts
+++ b/plugins/psv-extractor/src/index.ts
@@ -5,6 +5,8 @@ export const PSVExtractor = (options?: {
   dynamicTyping?: boolean
   skipEmptyLines?: boolean | 'greedy'
   transform?: (value: any) => Flatfile.CellValueUnion
+  chunkSize?: number
+  parallel?: number
 }) => {
   return DelimiterExtractor('.psv', { delimiter: '|', ...options })
 }

--- a/plugins/tsv-extractor/src/index.ts
+++ b/plugins/tsv-extractor/src/index.ts
@@ -5,6 +5,8 @@ export const TSVExtractor = (options?: {
   dynamicTyping?: boolean
   skipEmptyLines?: boolean | 'greedy'
   transform?: (value: any) => Flatfile.CellValueUnion
+  chunkSize?: number
+  parallel?: number
 }) => {
   return DelimiterExtractor('.tsv', { delimiter: '\t', ...options })
 }

--- a/plugins/xlsx-extractor/src/index.ts
+++ b/plugins/xlsx-extractor/src/index.ts
@@ -1,7 +1,11 @@
 import { parseBuffer } from './parser'
 import { Extractor } from '@flatfile/util-extractor'
 
-export const ExcelExtractor = (options?: { rawNumbers?: boolean }) => {
+export const ExcelExtractor = (options?: {
+  rawNumbers?: boolean
+  chunkSize?: number
+  parallel?: number
+}) => {
   return Extractor(/\.(xlsx?|xlsm|xlsb|xltx?|xltm)$/i, parseBuffer, options)
 }
 

--- a/plugins/xml-extractor/src/index.ts
+++ b/plugins/xml-extractor/src/index.ts
@@ -5,6 +5,8 @@ export const XMLExtractor = (options?: {
   separator?: string
   attributePrefix?: string
   transform?: (row: Record<string, any>) => Record<string, any>
+  chunkSize?: number
+  parallel?: number
 }) => {
   return Extractor('.xml', parseBuffer, options)
 }

--- a/utils/common/src/async.batch.ts
+++ b/utils/common/src/async.batch.ts
@@ -3,7 +3,7 @@ export async function asyncBatch<T, R>(
   callback: (chunk: T[]) => Promise<R>,
   options: { chunkSize?: number; parallel?: number } = {}
 ): Promise<R[]> {
-  const { chunkSize, parallel } = { chunkSize: 1000, parallel: 1, ...options }
+  const { chunkSize, parallel } = { chunkSize: 3000, parallel: 1, ...options }
   const results: R[] = []
 
   // Split the array into chunks

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -34,7 +34,7 @@ export const Extractor = (
             progress: 50,
             info: 'Adding records to Sheets',
           })
-          const { chunkSize = 1000, parallel = 1 } = options
+          const { chunkSize = 10000, parallel = 1 } = options
           for (const sheet of workbook.sheets) {
             if (!capture[sheet.name]) {
               continue

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -35,7 +35,6 @@ export const Extractor = (
             info: 'Adding records to Sheets',
           })
           const { chunkSize = 1000, parallel = 1 } = options
-          console.log(chunkSize, parallel)
           for (const sheet of workbook.sheets) {
             if (!capture[sheet.name]) {
               continue

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -34,6 +34,8 @@ export const Extractor = (
             progress: 50,
             info: 'Adding records to Sheets',
           })
+          const { chunkSize = 1000, parallel = 1 } = options
+          console.log(chunkSize, parallel)
           for (const sheet of workbook.sheets) {
             if (!capture[sheet.name]) {
               continue
@@ -43,7 +45,7 @@ export const Extractor = (
               async (chunk) => {
                 await api.records.insert(sheet.id, chunk)
               },
-              { chunkSize: 10000, parallel: 1 }
+              { chunkSize, parallel }
             )
           }
           await api.files.update(file.id, {

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -30,11 +30,18 @@ export const Extractor = (
             file,
             capture
           )
+          if (!workbook.sheets || workbook.sheets.length === 0) {
+            throw new Error('because no Sheets found')
+          }
           await api.jobs.ack(job.data.id, {
             progress: 50,
             info: 'Adding records to Sheets',
           })
-          const { chunkSize = 10000, parallel = 1 } = options
+          const { chunkSize, parallel } = {
+            chunkSize: 3000,
+            parallel: 1,
+            ...options,
+          }
           for (const sheet of workbook.sheets) {
             if (!capture[sheet.name]) {
               continue
@@ -78,7 +85,7 @@ async function createWorkbook(
   )
   const workbook = await api.workbooks.create(workbookConfig)
 
-  if (workbook.data.sheets.length === 0) {
+  if (!workbook.data.sheets || workbook.data.sheets.length === 0) {
     throw new Error('because no Sheets found')
   }
 


### PR DESCRIPTION
Guide PR: https://github.com/FlatFilers/Guides/pull/735

This PR adds the ability to configure batching options: `chunkSize` by default has a value of `1000`, `parallel` by default has a value of `1`. These can now be changed like so:

```
export default function (listener: FlatfileListener) {
  listener.use(JSONExtractor({ chunkSize: 100, parallel: 2 }))
  listener.use(ExcelExtractor({ chunkSize: 200, parallel: 2 }))
  listener.use(XMLExtractor({ chunkSize: 300, parallel: 2 }))
  listener.use(PSVExtractor({ chunkSize: 400, parallel: 2 }))
  listener.use(TSVExtractor({ chunkSize: 500, parallel: 2 }))
  listener.use(
    DelimiterExtractor('txt', { delimiter: '~', chunkSize: 600, parallel: 2 })
  )
  listener.use(
    DelimiterExtractor('semicolin', {
      delimiter: ';',
      chunkSize: 700,
      parallel: 2,
    })
  )
}
```