### PR TITLE
feat: pdf extractor plugin

### DIFF
--- a/.changeset/eighty-kiwis-cry.md
+++ b/.changeset/eighty-kiwis-cry.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-pdf-extractor': patch
+---
+
+Initial release

--- a/package-lock.json
+++ b/package-lock.json
@@ -13667,6 +13667,7 @@
         "@flatfile/api": "^1.5.14",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.4",
+        "@flatfile/util-file-buffer": "0.0.2",
         "axios": "^1.4.0",
         "fs-extra": "^11.1.1",
         "remeda": "^1.14.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1293,9 +1293,9 @@
       }
     },
     "node_modules/@flatfile/api": {
-      "version": "1.5.20",
-      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.5.20.tgz",
-      "integrity": "sha512-5EnM+mCQAMi0xu0X2BquZjbl8WbJghMUjNR9n6DxHU+t5SuBWmq8si0x5rYyQgka0FtecE9gGt6iD25vz2OmrQ==",
+      "version": "1.5.21",
+      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.5.21.tgz",
+      "integrity": "sha512-eHaeqR4YiMTpk4xVESQdJFGEmm2qZZhI69L6SWniI/uzcG47+0MTF8YjBUia0R2VdnNlWjG1IXM4dr4yWt8r0g==",
       "dependencies": {
         "@flatfile/cross-env-config": "0.0.4",
         "@types/url-join": "4.0.1",
@@ -1369,9 +1369,9 @@
       "integrity": "sha512-5HUBar6CnhhMU7lr4DnD79QfV4MtR1dUjZQJdt50HCS5pxy+tbF70JJSnoF/6itj+0hATkSC/Ep5C1XfABAGYw=="
     },
     "node_modules/@flatfile/listener": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@flatfile/listener/-/listener-0.3.13.tgz",
-      "integrity": "sha512-P7imrkRv9jKoGUw+klrCoIf5T1ebVjnzKwFrkdhc/NVSQ1YpNJedSCosvGVJ3NY7itiI4xd/bcnjkyHH/9OmgA==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@flatfile/listener/-/listener-0.3.14.tgz",
+      "integrity": "sha512-z7XBTtxW9tdYnvZl10YvfOQfcMy/uxBCJP4Hl/ZQmIjzhhPfQdndD0Fa+x8Su8wzKTVcjlK9t+DGMvsByHpCEg==",
       "dependencies": {
         "ansi-colors": "^4.1.3",
         "flat": "^5.0.2"
@@ -1442,6 +1442,10 @@
     },
     "node_modules/@flatfile/plugin-openapi": {
       "resolved": "plugins/openapi",
+      "link": true
+    },
+    "node_modules/@flatfile/plugin-pdf-extractor": {
+      "resolved": "plugins/pdf-extractor",
       "link": true
     },
     "node_modules/@flatfile/plugin-psv-extractor": {
@@ -4653,6 +4657,16 @@
       "integrity": "sha512-3zsplnP2djeps5P9OyarTxwRpMLoe5Ash8aL9iprw0JxB+FAHjY+ifn4yZUuW4/9hqtnmor6uvjSRzJhiVbrEQ==",
       "dev": true
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.1.tgz",
+      "integrity": "sha512-MxObHvNl4A69ofaTRU8DFqvgzzv8s9yRtaPPm5gud9HDNvpB3GPQFvNuTWAI59B9huVGV5jXYJwbCsmBsOGYWA==",
+      "dev": true,
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -4710,6 +4724,15 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.1.tgz",
+      "integrity": "sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -11607,9 +11630,9 @@
       }
     },
     "node_modules/remeda": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.24.0.tgz",
-      "integrity": "sha512-tjLxwU4yLtvX8yHlePnE7CdQXRe2pKatlVY+AunqAQV5t9FNw1yuiIAqKpu6zevd+No5LQHEJ/HK3r3ZFK7KXg=="
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.24.1.tgz",
+      "integrity": "sha512-BHJ43Um1Ykczaaz6Ew/I3JzJmU8DMB9uQgLBGf3XCKI9wxgsLIg1OX0YEv2qPUSUcwY/Nbk5kA97Yq9WnZs0Jg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -13636,6 +13659,57 @@
       "version": "0.0.2",
       "license": "ISC"
     },
+    "plugins/pdf-extractor": {
+      "name": "@flatfile/plugin-pdf-extractor",
+      "version": "0.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@flatfile/api": "^1.5.14",
+        "@flatfile/hooks": "^1.3.1",
+        "@flatfile/listener": "^0.3.4",
+        "axios": "^1.4.0",
+        "fs-extra": "^11.1.1",
+        "remeda": "^1.14.0"
+      },
+      "devDependencies": {
+        "@types/fs-extra": "^11.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "plugins/pdf-extractor/node_modules/fs-extra": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+      "integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "plugins/pdf-extractor/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "plugins/pdf-extractor/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "plugins/psv-extractor": {
       "name": "@flatfile/plugin-psv-extractor",
       "version": "1.3.4",
@@ -13738,7 +13812,7 @@
     },
     "plugins/zip-extractor": {
       "name": "@flatfile/plugin-zip-extractor",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",

--- a/plugins/pdf-extractor/CHANGELOG.md
+++ b/plugins/pdf-extractor/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @flatfile/plugin-pdf-extractor

--- a/plugins/pdf-extractor/README.md
+++ b/plugins/pdf-extractor/README.md
@@ -1,0 +1,9 @@
+# @flatfile/plugin-pdf-extractor
+
+This package parses a PDF file and extracts it into Flatfile.
+
+`npm i @flatfile/plugin-pdf-extractor`
+
+## Get Started
+
+Follow [this guide](https://flatfile.com/docs/plugins/extractors/pdf-extractor) to learn how to use the plugin.

--- a/plugins/pdf-extractor/package.json
+++ b/plugins/pdf-extractor/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@flatfile/plugin-pdf-extractor",
+  "version": "0.0.0",
+  "description": "A plugin for parsing PDF files in Flatfile.",
+  "registryMetadata": {
+    "category": "extractors"
+  },
+  "engines": {
+    "node": ">= 16"
+  },
+  "source": "src/index.ts",
+  "main": "dist/main.js",
+  "module": "dist/module.mjs",
+  "types": "dist/types.d.ts",
+  "scripts": {
+    "build": "parcel build",
+    "dev": "parcel watch",
+    "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
+    "test": "jest --passWithNoTests"
+  },
+  "keywords": [],
+  "author": "Flatfile, Inc.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FlatFilers/flatfile-plugins.git",
+    "directory": "plugins/pdf-extractor"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "@flatfile/api": "^1.5.14",
+    "@flatfile/hooks": "^1.3.1",
+    "@flatfile/listener": "^0.3.4",
+    "axios": "^1.4.0",
+    "fs-extra": "^11.1.1",
+    "remeda": "^1.14.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.1"
+  }
+}

--- a/plugins/pdf-extractor/package.json
+++ b/plugins/pdf-extractor/package.json
@@ -30,6 +30,7 @@
     "@flatfile/api": "^1.5.14",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.4",
+    "@flatfile/util-file-buffer": "0.0.2",
     "axios": "^1.4.0",
     "fs-extra": "^11.1.1",
     "remeda": "^1.14.0"

--- a/plugins/pdf-extractor/src/index.ts
+++ b/plugins/pdf-extractor/src/index.ts
@@ -1,5 +1,5 @@
 import { FlatfileListener } from '@flatfile/listener'
-import { fileBuffer } from '@flatfile/plugin-file-buffer'
+import { fileBuffer } from '@flatfile/util-file-buffer'
 
 import { PluginOptions, run } from './plugin'
 

--- a/plugins/pdf-extractor/src/index.ts
+++ b/plugins/pdf-extractor/src/index.ts
@@ -1,0 +1,19 @@
+import { FlatfileListener } from '@flatfile/listener'
+import { fileBuffer } from '@flatfile/plugin-file-buffer'
+
+import { PluginOptions, run } from './plugin'
+
+/**
+ * PDF extractor plugin for Flatfile.
+ *
+ * @param opts - plugin config options
+ */
+export const pdfExtractorPlugin = (opts: PluginOptions) => {
+  return (listener: FlatfileListener) => {
+    listener.use(
+      fileBuffer('.pdf', async (fileResource, buffer, event) => {
+        await run(event, fileResource, buffer, opts)
+      })
+    )
+  }
+}

--- a/plugins/pdf-extractor/src/plugin.ts
+++ b/plugins/pdf-extractor/src/plugin.ts
@@ -28,9 +28,7 @@ export const run = async (
   }
 
   if (R.isEmpty(opts.apiKey)) {
-    if (opts.debug) {
-      logWarn('Found invalid API key')
-    }
+    logError('Found invalid API key')
 
     return
   }

--- a/plugins/pdf-extractor/src/plugin.ts
+++ b/plugins/pdf-extractor/src/plugin.ts
@@ -28,7 +28,7 @@ export const run = async (
   }
 
   if (R.isEmpty(opts.apiKey) && opts.debug) {
-    logWarn("Found invalid API key")
+    logWarn('Found invalid API key')
 
     return
   }
@@ -46,7 +46,7 @@ export const run = async (
     const response = await axios.postForm(url, formData)
 
     if (response.status !== 200) {
-      logError("Failed to convert PDF on files.com")
+      logError('Failed to convert PDF on files.com')
 
       return
     }

--- a/plugins/pdf-extractor/src/plugin.ts
+++ b/plugins/pdf-extractor/src/plugin.ts
@@ -27,8 +27,10 @@ export const run = async (
     return
   }
 
-  if (R.isEmpty(opts.apiKey) && opts.debug) {
-    logWarn('Found invalid API key')
+  if (R.isEmpty(opts.apiKey)) {
+    if (opts.debug) {
+      logWarn('Found invalid API key')
+    }
 
     return
   }
@@ -52,8 +54,10 @@ export const run = async (
     }
 
     fs.writeFile(fileName, response.data, async (err: unknown) => {
-      if (err && opts.debug) {
-        logError('Error writing file to disk')
+      if (err) {
+        if (opts.debug) {
+          logError('Error writing file to disk')
+        }
 
         return
       }

--- a/plugins/pdf-extractor/src/plugin.ts
+++ b/plugins/pdf-extractor/src/plugin.ts
@@ -1,0 +1,91 @@
+import axios from 'axios'
+import api, { Flatfile } from '@flatfile/api'
+import { FlatfileEvent } from '@flatfile/listener'
+import * as fs from 'fs-extra'
+import * as R from 'remeda'
+
+/**
+ * Plugin config options.
+ *
+ * @property {string} apiKey - `pdftables.com` API key
+ * @property {boolean} debug - show helpful messages useful for debugging (usage intended for development)
+ */
+export interface PluginOptions {
+  readonly apiKey: string
+  readonly debug?: boolean
+}
+
+export const run = async (
+  event: FlatfileEvent,
+  file: Flatfile.File_,
+  buffer: Buffer,
+  opts: PluginOptions
+): Promise<void> => {
+  const { environmentId, spaceId } = event.context
+
+  if (file.ext !== 'pdf' || file.mode !== 'import') {
+    return
+  }
+
+  if (R.isEmpty(opts.apiKey)) {
+    return
+  }
+
+  try {
+    const url: string = `https://pdftables.com/api?key=${opts.apiKey}&format=csv`
+    const fileName: string = `${file.name.replace(
+      '.pdf',
+      ''
+    )}(Converted PDF)-${currentEpoch()}.csv`
+
+    const formData = new FormData()
+    formData.append('file', new Blob([buffer]))
+
+    const response = await axios.postForm(url, formData)
+
+    if (response.status !== 200) return
+
+    fs.writeFile(fileName, response.data, async (err: unknown) => {
+      if (err) {
+        logError('Error writing file to disk')
+      }
+
+      try {
+        const reader = fs.createReadStream(fileName)
+
+        await api.files.upload(reader, {
+          spaceId,
+          environmentId,
+          mode: 'import',
+        })
+
+        reader.close()
+      } catch (uploadError: unknown) {
+        logError('Failed to upload PDF->CSV file')
+        logError(JSON.stringify(uploadError, null, 2))
+      }
+    })
+  } catch (convertError: unknown) {
+    logError(JSON.stringify(convertError))
+  }
+
+  if (opts.debug) {
+    logInfo('Done')
+  }
+}
+
+const currentEpoch = (): string => {
+  return `${Math.floor(Date.now() / 1000)}`
+}
+
+const logError = (msg: string): void => {
+  console.error('[@flatfile/plugin-pdf-extractor]:[FATAL] ' + msg)
+}
+
+const logInfo = (msg: string): void => {
+  console.log('[@flatfile/plugin-pdf-extractor]:[INFO] ' + msg)
+}
+
+const logWarn = (msg: string): void => {
+  console.warn('[@flatfile/plugin-pdf-extractor]:[WARN] ' + msg)
+}


### PR DESCRIPTION
PDF extractor plugin that uses `pdftables.com` to handle PDF -> CSV conversion for upload to FF. [API](https://pdftables.com/pdf-to-excel-api) uses a blank row between pages. Customers are required to pay for the service themselves. 

https://www.loom.com/share/08744b5b94fd433789b4b115927ca22d?sid=4f844831-4d05-4825-b969-224d7228397e

### Usage

```ts
import { pdfExtractorPlugin } from "@flatfile/plugin-pdf-extractor";

export default function (listener: FlatfileListener) {
  listener.use(pdfExtractorPlugin({ apiKey: "key" }));
}
```