### PR TITLE
fix:change listener event

### DIFF
--- a/utils/file-buffer/src/index.ts
+++ b/utils/file-buffer/src/index.ts
@@ -10,7 +10,7 @@ export const fileBuffer = (
   ) => Promise<void> | void
 ) => {
   return (listener: FlatfileListener) => {
-    listener.on('file:created', async (event) => {
+    listener.on('upload:completed', async (event) => {
       const { data: file } = await api.files.get(event.context.fileId)
 
       if (typeof matchFile === 'string' && !file.name.endsWith(matchFile)) {


### PR DESCRIPTION
**Issue** 
Exporting a workbook fires a `file:created` event. When both plugins are active the extractor code picks up the `file:created` event and proceeds with extraction.

```
import { exportWorkbookPlugin } from '@flatfile/plugin-export-worbook'
import { ExcelExtractor } from '@flatfile/plugin-xlsx-extractor'

export default function (listener) {
  listener.use(exportWorkbookPlugin())
  listener.use(ExcelExtractor())
}
```

**Solution** 
Change extractor code to listen for the `upload:completed` event, rather than `file:created` since the latter event is fired from other routes than just file uploads.