### PR TITLE
fix: exclude exported files from fileBuffer

### DIFF
--- a/.changeset/brave-toes-fly.md
+++ b/.changeset/brave-toes-fly.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/util-file-buffer': patch
+---
+
+Only run fileBuffer on uploaded files

--- a/utils/file-buffer/src/index.ts
+++ b/utils/file-buffer/src/index.ts
@@ -12,6 +12,9 @@ export const fileBuffer = (
   return (listener: FlatfileListener) => {
     listener.on('file:created', async (event) => {
       const { data: file } = await api.files.get(event.context.fileId)
+      if (file.mode === 'export') {
+        return false
+      }
 
       if (typeof matchFile === 'string' && !file.name.endsWith(matchFile)) {
         return false


### PR DESCRIPTION
**Issue** 
Exporting a workbook fires a `file:created` event. If an Extractor plugins is active, it picks up the `file:created` event and proceeds to extract it.

```
import { exportWorkbookPlugin } from '@flatfile/plugin-export-worbook'
import { ExcelExtractor } from '@flatfile/plugin-xlsx-extractor'

export default function (listener) {
  listener.use(exportWorkbookPlugin())
  listener.use(ExcelExtractor())
}
```

**Solution** 
This PR adds a check to the fileBuffer to check the `file.mode`. If `file.mode === 'export'` the fileBuffer will ignore the event. 