### PR TITLE
feat: add field filter & replace sheetId with sheetSlug

### DIFF
--- a/.changeset/light-emus-rescue.md
+++ b/.changeset/light-emus-rescue.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-autocast': minor
+---
+
+This release introduces field filters, and replaces sheetId with sheetSlug as a sheet identifier.

--- a/.changeset/light-emus-rescue.md
+++ b/.changeset/light-emus-rescue.md
@@ -2,4 +2,4 @@
 '@flatfile/plugin-autocast': minor
 ---
 
-This release introduces field filters, and replaces sheetId with sheetSlug as a sheet identifier.
+This release introduces field filters, and enables filtering by either sheetId or sheetSlug.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12090,12 +12090,12 @@
     },
     "plugins/autocast": {
       "name": "@flatfile/plugin-autocast",
-      "version": "0.0.4",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",
         "@flatfile/listener": "^0.3.10",
-        "@flatfile/plugin-record-hook": "^1.0.1"
+        "@flatfile/plugin-record-hook": "^1.0.4"
       },
       "engines": {
         "node": ">= 16"
@@ -12136,12 +12136,12 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "0.4.3",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.2.4",
+        "@flatfile/util-extractor": "0.3.0",
         "papaparse": "^5.4.1",
         "remeda": "^1.14.0"
       },
@@ -12202,13 +12202,13 @@
     },
     "plugins/json-extractor": {
       "name": "@flatfile/plugin-json-extractor",
-      "version": "0.4.5",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.2.4",
+        "@flatfile/util-extractor": "0.3.0",
         "remeda": "^1.14.0"
       },
       "engines": {
@@ -12279,11 +12279,11 @@
     },
     "plugins/psv-extractor": {
       "name": "@flatfile/plugin-psv-extractor",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
-        "@flatfile/plugin-delimiter-extractor": "^0.4.0"
+        "@flatfile/plugin-delimiter-extractor": "^0.5.0"
       },
       "engines": {
         "node": ">= 16"
@@ -12291,13 +12291,13 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-common": "^0.1.0"
+        "@flatfile/util-common": "^0.1.1"
       },
       "devDependencies": {
         "axios": "^1.4.0"
@@ -12326,11 +12326,11 @@
     },
     "plugins/tsv-extractor": {
       "name": "@flatfile/plugin-tsv-extractor",
-      "version": "1.2.4",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
-        "@flatfile/plugin-delimiter-extractor": "^0.4.0"
+        "@flatfile/plugin-delimiter-extractor": "^0.5.0"
       },
       "engines": {
         "node": ">= 16"
@@ -12338,13 +12338,13 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.4.9",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.2.4",
+        "@flatfile/util-extractor": "0.3.0",
         "remeda": "^1.14.0",
         "xlsx": "^0.18.5"
       },
@@ -12374,12 +12374,12 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.2.4",
+        "@flatfile/util-extractor": "0.3.0",
         "@flatfile/util-file-buffer": "0.0.4",
         "remeda": "^1.24.0",
         "xml-json-format": "^1.0.8"
@@ -12417,7 +12417,7 @@
     },
     "utils/common": {
       "name": "@flatfile/util-common",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "engines": {
         "node": ">= 16"
@@ -12425,7 +12425,7 @@
     },
     "utils/extractor": {
       "name": "@flatfile/util-extractor",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12095,7 +12095,8 @@
       "dependencies": {
         "@flatfile/api": "^1.4.9",
         "@flatfile/listener": "^0.3.10",
-        "@flatfile/plugin-record-hook": "^1.0.4"
+        "@flatfile/plugin-record-hook": "^1.0.4",
+        "@flatfile/util-common": "^0.1.1"
       },
       "engines": {
         "node": ">= 16"

--- a/plugins/autocast/package.json
+++ b/plugins/autocast/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@flatfile/api": "^1.4.9",
     "@flatfile/listener": "^0.3.10",
-    "@flatfile/plugin-record-hook": "^1.0.4"
+    "@flatfile/plugin-record-hook": "^1.0.4",
+    "@flatfile/util-common": "^0.1.1"
   }
 }

--- a/plugins/autocast/src/autocast.plugin.ts
+++ b/plugins/autocast/src/autocast.plugin.ts
@@ -6,7 +6,7 @@ import { logInfo } from '@flatfile/util-common'
 
 export function autocast(
   sheetFilter: { sheetSlug?: string; sheetId?: string },
-  fieldFilter?: string[],
+  fieldFilters?: string[],
   options?: {
     chunkSize?: number
     parallel?: number
@@ -31,8 +31,8 @@ export function autocast(
           }
 
           const castableFields = sheet.data.config.fields.filter((field) =>
-            fieldFilter
-              ? fieldFilter.includes(field.key)
+            fieldFilters
+              ? fieldFilters.includes(field.key)
               : field.type !== 'string'
           )
           records.forEach((record) => {

--- a/plugins/autocast/src/autocast.plugin.ts
+++ b/plugins/autocast/src/autocast.plugin.ts
@@ -2,61 +2,64 @@ import api from '@flatfile/api'
 import { FlatfileListener, FlatfileEvent } from '@flatfile/listener'
 import { BulkRecordHook } from '@flatfile/plugin-record-hook'
 import { FlatfileRecord, TPrimitive } from '@flatfile/hooks'
+import { logInfo } from '@flatfile/util-common'
 
 export function autocast(
-  sheetSlug: string,
+  sheetFilter: { sheetSlug?: string; sheetId?: string },
   fieldFilter?: string[],
   options?: {
     chunkSize?: number
     parallel?: number
   }
 ) {
+  if (!sheetFilter.sheetSlug && !sheetFilter.sheetId) {
+    throw new Error('You must provide either a sheetSlug or sheetId')
+  }
+  if (sheetFilter.sheetSlug && sheetFilter.sheetId) {
+    throw new Error('You must provide either a sheetSlug or sheetId, not both')
+  }
   return async (listener: FlatfileListener) => {
-    listener.on(
-      'commit:created',
-      { sheetSlug },
-      async (event: FlatfileEvent) => {
-        return await BulkRecordHook(
-          event,
-          async (records: FlatfileRecord[]) => {
-            const sheetId = event.context.sheetId
-            const sheet = await api.sheets.get(sheetId)
-            if (!sheet) {
-              console.log(`Failed to fetch sheet with slug: ${sheetSlug}`)
-              return
-            }
+    listener.on('commit:created', sheetFilter, async (event: FlatfileEvent) => {
+      return await BulkRecordHook(
+        event,
+        async (records: FlatfileRecord[]) => {
+          const sheetId = event.context.sheetId
+          const sheet = await api.sheets.get(sheetId)
+          if (!sheet) {
+            logInfo('@flatfile/plugin-autocast', 'Failed to fetch sheet')
+            return
+          }
 
-            const castableFields = sheet.data.config.fields.filter((field) =>
-              fieldFilter
-                ? fieldFilter.includes(field.key)
-                : field.type !== 'string'
-            )
-            records.forEach((record) => {
-              castableFields.forEach((field) => {
-                const originalValue = record.get(field.key)
-                const caster = CASTING_FUNCTIONS[field.type]
+          const castableFields = sheet.data.config.fields.filter((field) =>
+            fieldFilter
+              ? fieldFilter.includes(field.key)
+              : field.type !== 'string'
+          )
+          records.forEach((record) => {
+            castableFields.forEach((field) => {
+              const originalValue = record.get(field.key)
+              const caster = CASTING_FUNCTIONS[field.type]
 
-                if (
-                  originalValue &&
-                  caster &&
-                  typeof originalValue !== field.type
-                ) {
-                  record.computeIfPresent(field.key, caster)
+              if (
+                originalValue &&
+                caster &&
+                typeof originalValue !== field.type
+              ) {
+                record.computeIfPresent(field.key, caster)
 
-                  if (originalValue === record.get(field.key)) {
-                    record.addError(
-                      field.key,
-                      `Failed to cast '${originalValue}' to '${field.type}'`
-                    )
-                  }
+                if (originalValue === record.get(field.key)) {
+                  record.addError(
+                    field.key,
+                    `Failed to cast '${originalValue}' to '${field.type}'`
+                  )
                 }
-              })
+              }
             })
-          },
-          options
-        )
-      }
-    )
+          })
+        },
+        options
+      )
+    })
   }
 }
 


### PR DESCRIPTION
This PR introduces an optional `fieldFilter`, and enables filtering by either `sheetId` or `sheetSlug`.

Example:
```
listener.use(autocast({ sheetId: 'us_sh_12345678' }))
listener.use(autocast({ sheetSlug: 'foo' }, ['numberField']))
listener.use(autocast({ sheetId: 'us_sh_12345678' }, ['numberField']))
listener.use(autocast({ sheetSlug: 'bar' }, ['numberField', 'dateField']))
```