### PR TITLE
chore: update @flatfile/api dependency version

### DIFF
--- a/.changeset/silver-ants-juggle.md
+++ b/.changeset/silver-ants-juggle.md
@@ -1,0 +1,25 @@
+---
+'@flatfile/plugin-delimiter-extractor': patch
+'@flatfile/util-response-rejection': patch
+'@flatfile/plugin-space-configure': patch
+'@flatfile/plugin-export-workbook': patch
+'@flatfile/plugin-json-extractor': patch
+'@flatfile/plugin-webhook-egress': patch
+'@flatfile/plugin-xlsx-extractor': patch
+'@flatfile/plugin-dxp-configure': patch
+'@flatfile/plugin-pdf-extractor': patch
+'@flatfile/plugin-psv-extractor': patch
+'@flatfile/plugin-tsv-extractor': patch
+'@flatfile/plugin-xml-extractor': patch
+'@flatfile/plugin-zip-extractor': patch
+'@flatfile/plugin-job-handler': patch
+'@flatfile/plugin-record-hook': patch
+'@flatfile/util-file-buffer': patch
+'@flatfile/plugin-autocast': patch
+'@flatfile/plugin-automap': patch
+'@flatfile/util-extractor': patch
+'@flatfile/plugin-dedupe': patch
+'@flatfile/utils-testing': patch
+---
+
+@flatfile/api dependency updated to latest version

--- a/package-lock.json
+++ b/package-lock.json
@@ -772,9 +772,9 @@
       }
     },
     "node_modules/@flatfile/api": {
-      "version": "1.5.25",
-      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.5.25.tgz",
-      "integrity": "sha512-NGQuGwnZ6F0JZODf9ecExuKe6fO0/ZgCTuZ7JmuOi/9F9nCR6+8rbjSiY3++iqAjAaB0wR9SwIf45Tv3ylfpHQ==",
+      "version": "1.5.26",
+      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.5.26.tgz",
+      "integrity": "sha512-d/UX6YF6M7LoT+wTxFDAnMOByV8MECkjoZ56KkPQCexg8ovOjpXpCRBli/JzCXkFXIM3poWGcdk6G2mOuIF5vg==",
       "dependencies": {
         "@flatfile/cross-env-config": "0.0.4",
         "@types/url-join": "4.0.1",
@@ -10358,7 +10358,7 @@
       "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.4.9",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.10",
         "@flatfile/plugin-record-hook": "^1.1.0",
         "@flatfile/util-common": "^0.2.0"
@@ -10372,7 +10372,7 @@
       "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.11",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/common-plugin-utils": "^1.0.1",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/utils-debugger": "^0.0.3",
@@ -10387,7 +10387,7 @@
       "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.14",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
         "remeda": "^1.14.0",
@@ -10405,7 +10405,7 @@
       "version": "0.7.2",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-extractor": "0.4.3",
         "papaparse": "^5.4.1",
@@ -10424,7 +10424,7 @@
       "version": "0.0.7",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.7"
+        "@flatfile/api": "^1.5.26"
       },
       "devDependencies": {
         "@flatfile/configure": "^0.5.32"
@@ -10438,7 +10438,7 @@
       "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.14",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
         "remeda": "^1.14.0",
@@ -10458,7 +10458,7 @@
       "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.4.9",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.0"
       },
@@ -10471,7 +10471,7 @@
       "version": "0.6.3",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.4.9",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-extractor": "0.4.3",
@@ -10502,7 +10502,7 @@
       "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.14",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-file-buffer": "0.1.0",
@@ -10551,7 +10551,7 @@
       "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13"
+        "@flatfile/api": "^1.5.26"
       },
       "engines": {
         "node": ">= 16"
@@ -10562,7 +10562,7 @@
       "version": "1.1.3",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.1",
@@ -10580,7 +10580,7 @@
       "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.4.9",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/plugin-job-handler": "^0.1.2"
       },
@@ -10598,7 +10598,7 @@
       "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13"
+        "@flatfile/api": "^1.5.26"
       },
       "engines": {
         "node": ">= 16"
@@ -10609,7 +10609,7 @@
       "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.14",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/plugin-job-handler": "^0.1.2",
         "@flatfile/util-common": "^0.2.1",
@@ -10622,10 +10622,10 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.7.3",
+      "version": "1.7.4",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.4.9",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-extractor": "0.4.3",
@@ -10641,7 +10641,7 @@
       "version": "0.5.3",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-extractor": "0.4.3",
         "@flatfile/util-file-buffer": "0.1.0",
@@ -10657,7 +10657,7 @@
       "version": "0.3.6",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.4.9",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.0",
@@ -10694,7 +10694,7 @@
       "version": "0.4.3",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.1",
         "@flatfile/util-file-buffer": "0.1.0",
@@ -10709,7 +10709,7 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15"
       },
       "engines": {
@@ -10721,7 +10721,7 @@
       "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.25"
+        "@flatfile/api": "^1.5.26"
       },
       "engines": {
         "node": ">= 16"
@@ -10732,7 +10732,7 @@
       "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.13",
+        "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/listener-driver-pubsub": "^1.0.0",
         "@jest/globals": "^29.6.4",

--- a/plugins/autocast/package.json
+++ b/plugins/autocast/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.4.9",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.10",
     "@flatfile/plugin-record-hook": "^1.1.0",
     "@flatfile/util-common": "^0.2.0"

--- a/plugins/automap/package.json
+++ b/plugins/automap/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.11",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/common-plugin-utils": "^1.0.1",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/utils-debugger": "^0.0.3",

--- a/plugins/dedupe/package.json
+++ b/plugins/dedupe/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.14",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.15",
     "remeda": "^1.14.0",

--- a/plugins/delimiter-extractor/package.json
+++ b/plugins/delimiter-extractor/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-extractor": "0.4.3",
     "papaparse": "^5.4.1",

--- a/plugins/dxp-configure/package.json
+++ b/plugins/dxp-configure/package.json
@@ -32,7 +32,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.7"
+    "@flatfile/api": "^1.5.26"
   },
   "devDependencies": {
     "@flatfile/configure": "^0.5.32"

--- a/plugins/export-worbook/package.json
+++ b/plugins/export-worbook/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.14",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.15",
     "remeda": "^1.14.0",

--- a/plugins/job-handler/package.json
+++ b/plugins/job-handler/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.4.9",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-common": "^0.2.0"
   }

--- a/plugins/json-extractor/package.json
+++ b/plugins/json-extractor/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.4.9",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/hooks": "^1.3.0",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-extractor": "0.4.3",

--- a/plugins/pdf-extractor/package.json
+++ b/plugins/pdf-extractor/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.14",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-file-buffer": "0.1.0",

--- a/plugins/psv-extractor/package.json
+++ b/plugins/psv-extractor/package.json
@@ -27,6 +27,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13"
+    "@flatfile/api": "^1.5.26"
   }
 }

--- a/plugins/record-hook/package.json
+++ b/plugins/record-hook/package.json
@@ -32,7 +32,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-common": "^0.2.1",

--- a/plugins/space-configure/package.json
+++ b/plugins/space-configure/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.4.9",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/plugin-job-handler": "^0.1.2"
   }

--- a/plugins/tsv-extractor/package.json
+++ b/plugins/tsv-extractor/package.json
@@ -27,6 +27,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13"
+    "@flatfile/api": "^1.5.26"
   }
 }

--- a/plugins/webhook-egress/package.json
+++ b/plugins/webhook-egress/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.14",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/plugin-job-handler": "^0.1.2",
     "@flatfile/util-response-rejection": "^0.1.1",

--- a/plugins/xlsx-extractor/package.json
+++ b/plugins/xlsx-extractor/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.4.9",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/hooks": "^1.3.0",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-extractor": "0.4.3",

--- a/plugins/xml-extractor/package.json
+++ b/plugins/xml-extractor/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-extractor": "0.4.3",
     "@flatfile/util-file-buffer": "0.1.0",

--- a/plugins/zip-extractor/package.json
+++ b/plugins/zip-extractor/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.4.9",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/hooks": "^1.3.0",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-common": "^0.2.0",

--- a/utils/extractor/package.json
+++ b/utils/extractor/package.json
@@ -24,7 +24,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-common": "^0.2.1",
     "@flatfile/util-file-buffer": "0.1.0",

--- a/utils/file-buffer/package.json
+++ b/utils/file-buffer/package.json
@@ -27,7 +27,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13",
+    "@flatfile/api": "^1.5.26",
     "@flatfile/listener": "^0.3.15"
   }
 }

--- a/utils/response-rejection/package.json
+++ b/utils/response-rejection/package.json
@@ -27,6 +27,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.25"
+    "@flatfile/api": "^1.5.26"
   }
 }

--- a/utils/testing/package.json
+++ b/utils/testing/package.json
@@ -23,7 +23,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.13",
+    "@flatfile/api": "^1.5.26",
     "@jest/globals": "^29.6.4",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/listener-driver-pubsub": "^1.0.0",


### PR DESCRIPTION
This PR updates the `@flatfile/api` dependency version to the latest release on all plugins.