### PR TITLE
feat: support configuring spaces w/o workbooks

### DIFF
--- a/.changeset/many-camels-tease.md
+++ b/.changeset/many-camels-tease.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-space-configure': patch
+---
+
+Allow configuring spaces with no workbooks

--- a/package-lock.json
+++ b/package-lock.json
@@ -10355,12 +10355,12 @@
     },
     "plugins/autocast": {
       "name": "@flatfile/plugin-autocast",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.10",
-        "@flatfile/plugin-record-hook": "^1.1.0",
+        "@flatfile/plugin-record-hook": "^1.1.4",
         "@flatfile/util-common": "^0.2.0"
       },
       "engines": {
@@ -10369,7 +10369,7 @@
     },
     "plugins/automap": {
       "name": "@flatfile/plugin-automap",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
@@ -10384,7 +10384,7 @@
     },
     "plugins/dedupe": {
       "name": "@flatfile/plugin-dedupe",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
@@ -10402,12 +10402,12 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.3",
+        "@flatfile/util-extractor": "0.4.4",
         "papaparse": "^5.4.1",
         "remeda": "^1.14.0"
       },
@@ -10421,7 +10421,7 @@
     },
     "plugins/dxp-configure": {
       "name": "@flatfile/plugin-dxp-configure",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26"
@@ -10435,7 +10435,7 @@
     },
     "plugins/export-worbook": {
       "name": "@flatfile/plugin-export-workbook",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
@@ -10455,7 +10455,7 @@
     },
     "plugins/job-handler": {
       "name": "@flatfile/plugin-job-handler",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
@@ -10468,13 +10468,13 @@
     },
     "plugins/json-extractor": {
       "name": "@flatfile/plugin-json-extractor",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.3",
+        "@flatfile/util-extractor": "0.4.4",
         "remeda": "^1.14.0"
       },
       "engines": {
@@ -10499,13 +10499,13 @@
     },
     "plugins/pdf-extractor": {
       "name": "@flatfile/plugin-pdf-extractor",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-file-buffer": "0.1.0",
+        "@flatfile/util-file-buffer": "0.1.1",
         "axios": "^1.4.0",
         "fs-extra": "^11.1.1",
         "remeda": "^1.14.0"
@@ -10548,7 +10548,7 @@
     },
     "plugins/psv-extractor": {
       "name": "@flatfile/plugin-psv-extractor",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26"
@@ -10559,7 +10559,7 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
@@ -10577,12 +10577,12 @@
     },
     "plugins/space-configure": {
       "name": "@flatfile/plugin-space-configure",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/plugin-job-handler": "^0.1.2"
+        "@flatfile/plugin-job-handler": "^0.1.3"
       },
       "engines": {
         "node": ">= 16"
@@ -10595,7 +10595,7 @@
     },
     "plugins/tsv-extractor": {
       "name": "@flatfile/plugin-tsv-extractor",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26"
@@ -10606,14 +10606,14 @@
     },
     "plugins/webhook-egress": {
       "name": "@flatfile/plugin-webhook-egress",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/plugin-job-handler": "^0.1.2",
+        "@flatfile/plugin-job-handler": "^0.1.3",
         "@flatfile/util-common": "^0.2.1",
-        "@flatfile/util-response-rejection": "^0.1.1",
+        "@flatfile/util-response-rejection": "^0.1.2",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10622,13 +10622,13 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.3",
+        "@flatfile/util-extractor": "0.4.4",
         "remeda": "^1.14.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
       },
@@ -10638,13 +10638,13 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.3",
-        "@flatfile/util-file-buffer": "0.1.0",
+        "@flatfile/util-extractor": "0.4.4",
+        "@flatfile/util-file-buffer": "0.1.1",
         "remeda": "^1.24.0",
         "xml-json-format": "^1.0.8"
       },
@@ -10654,14 +10654,14 @@
     },
     "plugins/zip-extractor": {
       "name": "@flatfile/plugin-zip-extractor",
-      "version": "0.3.6",
+      "version": "0.3.7",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.0",
-        "@flatfile/util-file-buffer": "^0.1.0",
+        "@flatfile/util-file-buffer": "^0.1.1",
         "adm-zip": "^0.5.10",
         "os": "^0.1.2",
         "remeda": "^1.14.0"
@@ -10691,13 +10691,13 @@
     },
     "utils/extractor": {
       "name": "@flatfile/util-extractor",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.1",
-        "@flatfile/util-file-buffer": "0.1.0",
+        "@flatfile/util-file-buffer": "0.1.1",
         "remeda": "^1.14.0"
       },
       "engines": {
@@ -10706,7 +10706,7 @@
     },
     "utils/file-buffer": {
       "name": "@flatfile/util-file-buffer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",
@@ -10718,7 +10718,7 @@
     },
     "utils/response-rejection": {
       "name": "@flatfile/util-response-rejection",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26"
@@ -10729,7 +10729,7 @@
     },
     "utils/testing": {
       "name": "@flatfile/utils-testing",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",

--- a/plugins/space-configure/src/space.configure.ts
+++ b/plugins/space-configure/src/space.configure.ts
@@ -46,13 +46,13 @@ export function configureSpace(
         )
         await tick(50, 'Workbook created')
 
-        if (workbookIds) {
-          await api.spaces.update(spaceId, {
-            environmentId: environmentId,
-            primaryWorkbookId: workbookIds[0],
-            ...config.space,
-          })
-        }
+        await api.spaces.update(spaceId, {
+          environmentId: environmentId,
+          primaryWorkbookId:
+            workbookIds && workbookIds.length > 0 ? workbookIds[0] : '',
+          ...config.space,
+        })
+
         if (callback) {
           await callback(event, workbookIds, tick)
         }


### PR DESCRIPTION
This PR allows spaces to be configured without providing workbooks.

Simplistic usage:
```
listener.use(
  configureSpace({
    workbooks: [],
  })
)
```
