### PR TITLE
feat: automap match on sheet slug

### DIFF
--- a/.changeset/thin-dodos-jog.md
+++ b/.changeset/thin-dodos-jog.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-automap': minor
+---
+
+Match on sheet slug (in addition to sheet name & id)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10517,7 +10517,7 @@
     },
     "plugins/merge-connection": {
       "name": "@flatfile/plugin-connect-via-merge",
-      "version": "0.0.0-alpha.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.27",
@@ -10624,7 +10624,7 @@
     },
     "plugins/space-configure": {
       "name": "@flatfile/plugin-space-configure",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.26",

--- a/plugins/automap/src/automap.service.ts
+++ b/plugins/automap/src/automap.service.ts
@@ -43,7 +43,6 @@ export class AutomapService {
       const file = await this.getFileById(fileId)
 
       if (!this.isFileNameMatch(file)) {
-        await this.updateFileName(file.id, `⏸️️ ${file.name}`)
         return
       } else {
         await this.updateFileName(file.id, `⚡️ ${file.name}`)
@@ -257,6 +256,9 @@ export class AutomapService {
       // allow mapping to continue b/c we weren't explicitly told not to
       return true
     } else {
+      if (regex.global) {
+        regex.lastIndex = 0
+      }
       return regex.test(file.name)
     }
   }

--- a/plugins/automap/src/automap.service.ts
+++ b/plugins/automap/src/automap.service.ts
@@ -77,7 +77,12 @@ export class AutomapService {
 
             destinationSheet = R.pipe(
               destinationWorkbook.sheets,
-              R.find((s) => s.name === target || s.id === target)
+              R.find(
+                (s) =>
+                  s.name === target ||
+                  s.id === target ||
+                  s.config.slug === target
+              )
             )
 
             const destinationSheetId = destinationSheet?.id


### PR DESCRIPTION
Prior to this PR, the Automap plugin would match the provided `defaultTargetSheet` to the `sheet.name` or `sheet.id`. This PR includes matching the `defaultTargetSheet` to the `sheet.slug`.

Also remove pause icon to give better support for multiple automap listeners:
<img width="627" alt="Screenshot 2023-10-09 at 20 34 57" src="https://github.com/FlatFilers/flatfile-plugins/assets/4754531/5dac4b7e-be9b-48f2-91f0-d1c975a91573">

Guide PR: https://github.com/FlatFilers/Guides/pull/858
Closes: https://github.com/FlatFilers/support-triage/issues/697