### PR TITLE
feat: add raw option to Excel extractor

### DIFF
--- a/.changeset/sweet-bears-jump.md
+++ b/.changeset/sweet-bears-jump.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-xlsx-extractor': minor
+---
+
+Expose `raw` option to display raw data. Default to formatted text.

--- a/plugins/xlsx-extractor/src/index.ts
+++ b/plugins/xlsx-extractor/src/index.ts
@@ -1,12 +1,24 @@
 import { Extractor } from '@flatfile/util-extractor'
 import { parseBuffer } from './parser'
 
-export const ExcelExtractor = (options?: {
-  rawNumbers?: boolean
-  chunkSize?: number
-  parallel?: number
-  debug?: boolean
-}) => {
+/**
+ * Plugin config options.
+ *
+ * @property {boolean} raw - if true, return raw data; if false, return formatted text.
+ * @property {boolean} rawNumbers - if true, return raw numbers; if false, return formatted numbers.
+ * @property {number} chunkSize - the size of chunk to process when inserting records.
+ * @property {number} parallel - the quantity of parallel process when inserting records.
+ * @property {boolean} debug - if true, display helpful console logs.
+ */
+export interface ExcelExtractorOptions {
+  readonly raw?: boolean
+  readonly rawNumbers?: boolean
+  readonly chunkSize?: number
+  readonly parallel?: number
+  readonly debug?: boolean
+}
+
+export const ExcelExtractor = (options?: ExcelExtractorOptions) => {
   return Extractor(
     /\.(xlsx?|xlsm|xlsb|xltx?|xltm)$/i,
     'excel',

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -6,6 +6,7 @@ import { Flatfile } from '@flatfile/api'
 export function parseBuffer(
   buffer: Buffer,
   options?: {
+    raw?: boolean
     rawNumbers?: boolean
   }
 ): WorkbookCapture {
@@ -15,7 +16,11 @@ export function parseBuffer(
   })
 
   return mapValues(workbook.Sheets, (value, key) => {
-    return convertSheet(value, options?.rawNumbers || false)
+    return convertSheet(
+      value,
+      options?.rawNumbers || false,
+      options?.raw || false
+    )
   })
 }
 
@@ -26,12 +31,14 @@ export function parseBuffer(
  */
 function convertSheet(
   sheet: XLSX.WorkSheet,
-  rawNumbers: boolean
+  rawNumbers: boolean,
+  raw: boolean
 ): SheetCapture {
   let rows = XLSX.utils.sheet_to_json<Record<string, any>>(sheet, {
     header: 'A',
     defval: null,
     rawNumbers: rawNumbers || false,
+    raw: raw || false,
   })
 
   const { headerRow, skip } = detectHeader(rows)


### PR DESCRIPTION
This PR exposes SheetJS's `raw` option to the `ExcelExtractor`. This option allows preserving formatted text by default. If `raw` is set to true, it will return the raw value.

Guide PR: https://github.com/FlatFilers/Guides/pull/874