### PR TITLE
feat: ignore mapping jobs not created by automap plugin

### DIFF
--- a/.changeset/serious-cherries-hang.md
+++ b/.changeset/serious-cherries-hang.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-automap': patch
+---
+
+Ignore `workbook:map` jobs that weren't created by the automap plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -10396,12 +10396,12 @@
     },
     "plugins/autocast": {
       "name": "@flatfile/plugin-autocast",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/listener": "^0.3.10",
-        "@flatfile/plugin-record-hook": "^1.1.4",
+        "@flatfile/plugin-record-hook": "^1.1.6",
         "@flatfile/util-common": "^0.2.0"
       },
       "engines": {
@@ -10410,7 +10410,7 @@
     },
     "plugins/automap": {
       "name": "@flatfile/plugin-automap",
-      "version": "0.0.4",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10425,7 +10425,7 @@
     },
     "plugins/dedupe": {
       "name": "@flatfile/plugin-dedupe",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10443,12 +10443,12 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.5",
+        "@flatfile/util-extractor": "0.4.6",
         "papaparse": "^5.4.1",
         "remeda": "^1.14.0"
       },
@@ -10462,7 +10462,7 @@
     },
     "plugins/dxp-configure": {
       "name": "@flatfile/plugin-dxp-configure",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30"
@@ -10476,7 +10476,7 @@
     },
     "plugins/export-worbook": {
       "name": "@flatfile/plugin-export-workbook",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10496,7 +10496,7 @@
     },
     "plugins/job-handler": {
       "name": "@flatfile/plugin-job-handler",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10509,13 +10509,13 @@
     },
     "plugins/json-extractor": {
       "name": "@flatfile/plugin-json-extractor",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.5",
+        "@flatfile/util-extractor": "0.4.6",
         "remeda": "^1.14.0"
       },
       "engines": {
@@ -10529,14 +10529,14 @@
     },
     "plugins/merge-connection": {
       "name": "@flatfile/plugin-connect-via-merge",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/plugin-job-handler": "^0.1.2",
-        "@flatfile/plugin-space-configure": "^0.1.2",
+        "@flatfile/plugin-job-handler": "^0.1.4",
+        "@flatfile/plugin-space-configure": "^0.1.5",
         "@flatfile/util-common": "^0.2.1",
         "@mergeapi/merge-node-client": "^0.1.6",
         "axios": "^1.5.1"
@@ -10558,13 +10558,13 @@
     },
     "plugins/pdf-extractor": {
       "name": "@flatfile/plugin-pdf-extractor",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-file-buffer": "0.1.1",
+        "@flatfile/util-file-buffer": "0.1.2",
         "axios": "^1.4.0",
         "fs-extra": "^11.1.1",
         "remeda": "^1.14.0"
@@ -10607,7 +10607,7 @@
     },
     "plugins/psv-extractor": {
       "name": "@flatfile/plugin-psv-extractor",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30"
@@ -10618,7 +10618,7 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10636,12 +10636,12 @@
     },
     "plugins/space-configure": {
       "name": "@flatfile/plugin-space-configure",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/plugin-job-handler": "^0.1.3"
+        "@flatfile/plugin-job-handler": "^0.1.4"
       },
       "engines": {
         "node": ">= 16"
@@ -10654,7 +10654,7 @@
     },
     "plugins/tsv-extractor": {
       "name": "@flatfile/plugin-tsv-extractor",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30"
@@ -10665,14 +10665,14 @@
     },
     "plugins/webhook-egress": {
       "name": "@flatfile/plugin-webhook-egress",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/plugin-job-handler": "^0.1.3",
+        "@flatfile/plugin-job-handler": "^0.1.4",
         "@flatfile/util-common": "^0.2.1",
-        "@flatfile/util-response-rejection": "^0.1.2",
+        "@flatfile/util-response-rejection": "^0.1.3",
         "axios": "^1.4.0"
       },
       "engines": {
@@ -10681,13 +10681,13 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.7.6",
+      "version": "1.7.7",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.5",
+        "@flatfile/util-extractor": "0.4.6",
         "remeda": "^1.14.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
       },
@@ -10697,13 +10697,13 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/listener": "^0.3.15",
-        "@flatfile/util-extractor": "0.4.5",
-        "@flatfile/util-file-buffer": "0.1.1",
+        "@flatfile/util-extractor": "0.4.6",
+        "@flatfile/util-file-buffer": "0.1.2",
         "remeda": "^1.24.0",
         "xml-json-format": "^1.0.8"
       },
@@ -10713,14 +10713,14 @@
     },
     "plugins/zip-extractor": {
       "name": "@flatfile/plugin-zip-extractor",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.0",
-        "@flatfile/util-file-buffer": "^0.1.1",
+        "@flatfile/util-file-buffer": "^0.1.2",
         "adm-zip": "^0.5.10",
         "os": "^0.1.2",
         "remeda": "^1.14.0"
@@ -10750,13 +10750,13 @@
     },
     "utils/extractor": {
       "name": "@flatfile/util-extractor",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.1",
-        "@flatfile/util-file-buffer": "0.1.1",
+        "@flatfile/util-file-buffer": "0.1.2",
         "remeda": "^1.14.0"
       },
       "engines": {
@@ -10765,7 +10765,7 @@
     },
     "utils/file-buffer": {
       "name": "@flatfile/util-file-buffer",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10777,7 +10777,7 @@
     },
     "utils/response-rejection": {
       "name": "@flatfile/util-response-rejection",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30"
@@ -10788,7 +10788,7 @@
     },
     "utils/testing": {
       "name": "@flatfile/utils-testing",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",


### PR DESCRIPTION
Issue:
If the "import" process is started (either by dropping a file into a sheet or by clicking the "Import" button from a file), a secondary `workbook:map` job is created, which was being picked up by the automap plugin and resulted in duplicate entries in a sheet.

Solution:
This PR adds a `isAutomap` flag to the job's `input` to allow the automap plugin to filter on. If the flag isn't provided automap will just return.

Closes: https://github.com/FlatFilers/support-triage/issues/708