### PR TITLE
Add "next" URL to job completion response

### DIFF
--- a/.changeset/few-suits-rule.md
+++ b/.changeset/few-suits-rule.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-export-workbook': patch
+---
+
+Add "Next" url to job completion message

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -198,6 +198,11 @@ export const run = async (
         outcome: {
           message:
             'Data was successfully written to Excel file and uploaded. You can access the workbook in the "Available Downloads" section of the Files page in Flatfile.',
+            next: {
+              type: 'url',
+              url: `https://spaces.flatfile.com/space/${spaceId}/files?mode=export`,
+              label: 'Available Downloads',
+            },
         },
       })
 

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -198,11 +198,11 @@ export const run = async (
         outcome: {
           message:
             'Data was successfully written to Excel file and uploaded. You can access the workbook in the "Available Downloads" section of the Files page in Flatfile.',
-            next: {
-              type: 'url',
-              url: `https://spaces.flatfile.com/space/${spaceId}/files?mode=export`,
-              label: 'Available Downloads',
-            },
+          next: {
+            type: 'url',
+            url: `/space/${spaceId}/files?mode=export`,
+            label: 'Available Downloads',
+          },
         },
       })
 


### PR DESCRIPTION
Added a "next" action in the job completion response that redirects users to the "Available Downloads" section of the Files page in Flatfile.

This enhancement provides a smoother user experience by guiding users directly to their exported files.