### PR TITLE
chore: excel formatting

### DIFF
--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -95,7 +95,11 @@ export const run = async (
                     // '0' is not a valid accessible index in a worksheet and '1' is the header row
                     const cell =
                       worksheet[
-                        `${alphaColumnDesignations[colIdx]}${rowIdx + 2}`
+                        `${
+                          alphaColumnDesignations[
+                            colIdx + (options?.includeRecordIds ? 1 : 0)
+                          ]
+                        }${rowIdx + 2}`
                       ]
 
                     cell.c = R.pipe(
@@ -105,6 +109,7 @@ export const run = async (
                         t: `[${m.type.toUpperCase()}]: ${m.message}`,
                       }))
                     )
+                    cell.c.hidden = true
                   }
                 })
               )


### PR DESCRIPTION
- [x] hide comments by default
- [x] resolve issue with comments applied to the wrong cell when ids are exported
- [ ] set background of error cells
- [ ] format header better