### PR TITLE
chore: recordHook dep update

### DIFF
--- a/.changeset/bright-numbers-guess.md
+++ b/.changeset/bright-numbers-guess.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': patch
+---
+
+Dependency update

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,9 +782,9 @@
       }
     },
     "node_modules/@flatfile/api": {
-      "version": "1.5.32",
-      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.5.32.tgz",
-      "integrity": "sha512-S8F23+NnPjXrONWJhWYiGI0WO2sQsJBESBI6g1MSFz5jmswIkguxFmffhp0gj+A8zfYoHpyhlhYbuKMYzBcyEw==",
+      "version": "1.5.33",
+      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.5.33.tgz",
+      "integrity": "sha512-KP7NzP0q7ekXDWGl4yANCPpZmovNTJT2r3oafvlIu5rYvWwe/QDJZkmOsMOax7kIeH5tvEx0wW6Z7xW34JTZPg==",
       "dependencies": {
         "@flatfile/cross-env-config": "0.0.4",
         "@types/pako": "2.0.1",
@@ -10488,7 +10488,7 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10537,7 +10537,7 @@
     },
     "plugins/export-workbook": {
       "name": "@flatfile/plugin-export-workbook",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10570,7 +10570,7 @@
     },
     "plugins/json-extractor": {
       "name": "@flatfile/plugin-json-extractor",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10682,7 +10682,7 @@
       "version": "1.1.7",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.30",
+        "@flatfile/api": "^1.5.33",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.15",
         "@flatfile/util-common": "^0.2.1",
@@ -10742,7 +10742,7 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10758,7 +10758,7 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.5.6",
+      "version": "0.5.7",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.30",
@@ -10803,7 +10803,7 @@
     },
     "utils/common": {
       "name": "@flatfile/util-common",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.32"

--- a/plugins/record-hook/package.json
+++ b/plugins/record-hook/package.json
@@ -32,7 +32,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.30",
+    "@flatfile/api": "^1.5.33",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.15",
     "@flatfile/util-common": "^0.2.1",


### PR DESCRIPTION
This PR updates the `@flatfile/api` dependency to the latest (1.5.33) version.