### PR TITLE
fix: recordHook deep comparison of modified Records

### DIFF
--- a/.changeset/cyan-parents-worry.md
+++ b/.changeset/cyan-parents-worry.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': patch
+---
+
+Fix to compare full Record objects instead of just Record values

--- a/package-lock.json
+++ b/package-lock.json
@@ -10679,7 +10679,7 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.33",


### PR DESCRIPTION
This PR introduces deep comparison of the original record with the presumably modified record to accurately send only patches for updated records.

Fixes: https://github.com/FlatFilers/support-triage/issues/739