### PR TITLE
fix: check trackChanges flag before completing commit

### DIFF
--- a/.changeset/afraid-melons-sniff.md
+++ b/.changeset/afraid-melons-sniff.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': patch
+---
+
+Only complete commits when trackChanges is enabled on the Workbook

--- a/package-lock.json
+++ b/package-lock.json
@@ -10679,7 +10679,7 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.33",


### PR DESCRIPTION
This PR fixes an issue caused by trying to complete a commit when the `trackChanges` flag is disabled on the Workbook.

Fixes: https://github.com/FlatFilers/support-triage/issues/748