### PR TITLE
feat: cleaner recordHook error messages

### DIFF
--- a/.changeset/few-yaks-fetch.md
+++ b/.changeset/few-yaks-fetch.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': patch
+---
+
+Human-readable errors from recordHook

--- a/plugins/record-hook/src/RecordHook.ts
+++ b/plugins/record-hook/src/RecordHook.ts
@@ -18,13 +18,17 @@ export const RecordHook = async (
   ) => any | Promise<any>,
   options: RecordHookOptions = {}
 ) => {
-  const { concurrency } = { concurrency: 10, ...options }
+  const { concurrency = 10 } = options
   return BulkRecordHook(
     event,
     async (records, event) => {
       const handlers = await records.map((record: FlatfileRecord) =>
         Effect.promise(async () => {
-          await handler(record, event)
+          try {
+            await handler(record, event)
+          } catch (e) {
+            console.log(`An error occurred while running the handler: ${e}`)
+          }
         })
       )
       return Effect.runPromise(


### PR DESCRIPTION
This PR makes error messages readable (so long `FiberFailure`)