### PR TITLE
fix: show a modal instead of a toast when jobHandler catches an error

### DIFF
--- a/.changeset/nice-peas-yell.md
+++ b/.changeset/nice-peas-yell.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-job-handler': patch
+---
+
+Display Modal instead of a Toast on Job error

--- a/plugins/job-handler/src/job.handler.ts
+++ b/plugins/job-handler/src/job.handler.ts
@@ -71,6 +71,7 @@ export function jobHandler(
           outcome ?? {
             info: String(error.message),
             outcome: {
+              acknowledge: true,
               message: String(error.message),
             },
           }


### PR DESCRIPTION
closes https://github.com/FlatFilers/support-triage/issues/796

Changes the jobHandler to set `acknowledge:true` in the job outcome used in the catch block, so that errors show up in a Modal instead of a Toast. This fixes a problem where `space:configure` jobs finish faster than the space can load to see a job event that would trigger a Toast.