### PR TITLE
feat: handle empty sheets & enable dense mode for improved memory usage

### DIFF
--- a/.changeset/cyan-ligers-teach.md
+++ b/.changeset/cyan-ligers-teach.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/plugin-xlsx-extractor': patch
+'@flatfile/util-extractor': patch
+---
+
+Fix for xlsx extraction when file contains empty sheets

--- a/package-lock.json
+++ b/package-lock.json
@@ -23857,12 +23857,12 @@
     },
     "plugins/autocast": {
       "name": "@flatfile/plugin-autocast",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.45",
         "@flatfile/listener": "^0.3.17",
-        "@flatfile/plugin-record-hook": "^1.1.12",
+        "@flatfile/plugin-record-hook": "^1.2.0",
         "@flatfile/util-common": "^0.2.3"
       },
       "devDependencies": {
@@ -23914,12 +23914,12 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.37",
         "@flatfile/listener": "^0.3.17",
-        "@flatfile/util-extractor": "0.4.7",
+        "@flatfile/util-extractor": "0.4.8",
         "papaparse": "^5.4.1",
         "remeda": "^1.14.0"
       },
@@ -24131,7 +24131,7 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.1.14",
+      "version": "1.2.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.37",
@@ -24199,13 +24199,13 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.37",
         "@flatfile/hooks": "^1.3.0",
         "@flatfile/listener": "^0.3.17",
-        "@flatfile/util-extractor": "0.4.7",
+        "@flatfile/util-extractor": "0.4.8",
         "remeda": "^1.14.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
       },
@@ -24215,12 +24215,12 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.5.8",
+      "version": "0.5.9",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.37",
         "@flatfile/listener": "^0.3.17",
-        "@flatfile/util-extractor": "0.4.7",
+        "@flatfile/util-extractor": "0.4.8",
         "@flatfile/util-file-buffer": "0.1.3",
         "remeda": "^1.24.0",
         "xml-json-format": "^1.0.8"
@@ -24311,7 +24311,7 @@
     },
     "utils/extractor": {
       "name": "@flatfile/util-extractor",
-      "version": "0.4.7",
+      "version": "0.4.8",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.5.37",

--- a/plugins/xlsx-extractor/src/header.detection.ts
+++ b/plugins/xlsx-extractor/src/header.detection.ts
@@ -54,7 +54,7 @@ export abstract class Headerizer {
 }
 
 export const countNonEmptyCells = (row: string[]): number => {
-  return row.filter((cell) => cell.trim() !== '').length
+  return row.filter((cell) => `${cell}`.trim() !== '').length
 }
 
 // This is the original / default implementation of detectHeader.

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -62,6 +62,8 @@ async function convertSheet(
     rawNumbers,
     raw,
   })
+
+  // return if there are no rows
   if (!rows || rows.length === 0) {
     return
   }
@@ -72,7 +74,12 @@ async function convertSheet(
   const headerizer = Headerizer.create(headerDetectionOptions)
   const headerStream = Readable.from(extractValues(rows))
   const { header, skip } = await headerizer.getHeaders(headerStream)
+
   rows.splice(0, skip)
+  // return if there are no rows
+  if (rows.length === 0) {
+    return
+  }
 
   const toExcelHeader = (data: string[], keys: string[]) =>
     data.reduce((result, value, index) => {

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -16,6 +16,7 @@ export async function parseBuffer(
   const workbook = XLSX.read(buffer, {
     type: 'buffer',
     cellDates: true,
+    dense: true,
   })
   const sheetNames = Object.keys(workbook.Sheets)
   try {

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -66,7 +66,7 @@ export const Extractor = (
             capture
           )
           if (!workbook.sheets || workbook.sheets.length === 0) {
-            throw new Error('because no Sheets found')
+            throw new Error('No Sheets found')
           }
           await tick(10, 'Adding records to Sheets')
 
@@ -106,9 +106,12 @@ export const Extractor = (
           })
           console.log(workbook)
         } catch (e) {
-          console.log(`error ${e}`)
+          console.log(`Extractor error: ${e.message}`)
           await api.jobs.fail(jobId, {
-            info: `Extraction failed ${e.message}`,
+            info: 'Extraction failed',
+            outcome: {
+              message: e.message,
+            },
           })
         }
       }
@@ -130,7 +133,7 @@ async function createWorkbook(
   const workbook = await api.workbooks.create(workbookConfig)
 
   if (!workbook.data.sheets || workbook.data.sheets.length === 0) {
-    throw new Error('because no Sheets found')
+    throw new Error('No Sheets found')
   }
 
   return workbook.data


### PR DESCRIPTION
This PR fixes extraction failure when an xlsx file contains empty sheets. Additionally it enables [`dense` mode](https://docs.sheetjs.com/docs/demos/bigdata/stream/#dense-mode) for improved memory usage when extracting an exceptionally large file.

Test file: [Book1.xlsx](https://github.com/FlatFilers/flatfile-plugins/files/13618616/Book1.xlsx)

```
// One xlsx sheet will be extracted
listener.use(ExcelExtractor())

// Two xlsx sheets will be extracted
listener.use(
  ExcelExtractor({
    headerDetectionOptions: {
      algorithm: 'explicitHeaders',
      headers: ['One', 'Two', 'Three'],
    },
  })
)
```

Closes: https://github.com/FlatFilers/flatfile-plugins/issues/200 & https://github.com/FlatFilers/support-triage/issues/821 & https://github.com/FlatFilers/support-triage/issues/839