### PR TITLE
feat: refactor export-workbook plugin

### DIFF
--- a/.changeset/sweet-peaches-dream.md
+++ b/.changeset/sweet-peaches-dream.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/plugin-export-workbook': patch
+'@flatfile/util-common': patch
+---
+
+Export workbook plugin bug fix for handling multiple comments on a cell

--- a/package-lock.json
+++ b/package-lock.json
@@ -23950,9 +23950,10 @@
       "version": "0.0.10",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.5.37",
+        "@flatfile/api": "^1.5.44",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.17",
+        "@flatfile/util-common": "^0.2.4",
         "remeda": "^1.14.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
       },
@@ -23980,7 +23981,7 @@
     },
     "plugins/json-extractor": {
       "name": "@flatfile/plugin-json-extractor",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^0.4.9"
@@ -23991,17 +23992,6 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-typescript": "^11.1.5",
         "rollup": "^4.3.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "plugins/json-extractor/node_modules/@flatfile/util-file-buffer": {
-      "version": "0.1.2",
-      "license": "ISC",
-      "dependencies": {
-        "@flatfile/api": "^1.5.30",
-        "@flatfile/listener": "^0.3.15"
       },
       "engines": {
         "node": ">= 16"

--- a/plugins/export-workbook/package.json
+++ b/plugins/export-workbook/package.json
@@ -27,9 +27,10 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.5.37",
+    "@flatfile/api": "^1.5.44",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.17",
+    "@flatfile/util-common": "^0.2.4",
     "remeda": "^1.14.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
   }

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -1,10 +1,14 @@
 import api, { Flatfile } from '@flatfile/api'
 import { FlatfileEvent } from '@flatfile/listener'
-import { processRecords } from '@flatfile/util-common'
+import {
+  logError,
+  logInfo,
+  logWarn,
+  processRecords,
+} from '@flatfile/util-common'
 import * as fs from 'fs'
 import * as R from 'remeda'
 import * as XLSX from 'xlsx'
-import { logError, logInfo, logWarn } from '../../../utils/common/src'
 
 /**
  * Plugin config options.

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -79,7 +79,6 @@ export const run = async (
                             T: true,
                           }))
                           cell.c.hidden = true
-                          console.dir(cell, { depth: null })
                         }
 
                         return cell

--- a/utils/common/src/process.records.ts
+++ b/utils/common/src/process.records.ts
@@ -2,7 +2,9 @@ import api, { Flatfile } from '@flatfile/api'
 
 export async function processRecords<R>(
   sheetId: string,
-  callback: (records: Flatfile.RecordsWithLinks) => Promise<R | void>,
+  callback: (
+    records: Flatfile.RecordsWithLinks
+  ) => R | void | Promise<R | void>,
   recordGetOptions?: Omit<Flatfile.records.GetRecordsRequest, 'pageNumber'>
 ): Promise<R[] | void> {
   let pageNumber = 1


### PR DESCRIPTION
This PR refactors the export-workbook plugin and fixes a bug when multiple comments exist on a cell by threading them.

**Closes:** https://github.com/FlatFilers/support-triage/issues/814