### PR TITLE
feat: replace effect library

### DIFF
--- a/.changeset/plenty-brooms-scream.md
+++ b/.changeset/plenty-brooms-scream.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': patch
+---
+
+Replace the effect library in favor of custom concurrency control in recordHook

--- a/package-lock.json
+++ b/package-lock.json
@@ -5515,10 +5515,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/effect": {
-      "version": "2.0.0-next.60",
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.611",
       "license": "ISC"
@@ -12050,8 +12046,7 @@
         "@flatfile/api": "^1.6.0",
         "@flatfile/hooks": "^1.3.1",
         "@flatfile/listener": "^0.3.17",
-        "@flatfile/util-common": "^0.2.5",
-        "effect": "^2.0.0-next.29"
+        "@flatfile/util-common": "^0.2.5"
       },
       "devDependencies": {
         "@flatfile/utils-testing": "^0.0.7",
@@ -12290,7 +12285,7 @@
     },
     "utils/response-rejection": {
       "name": "@flatfile/util-response-rejection",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.6.0",

--- a/plugins/record-hook/package.json
+++ b/plugins/record-hook/package.json
@@ -41,8 +41,7 @@
     "@flatfile/api": "^1.6.0",
     "@flatfile/hooks": "^1.3.1",
     "@flatfile/listener": "^0.3.17",
-    "@flatfile/util-common": "^0.2.5",
-    "effect": "^2.0.0-next.29"
+    "@flatfile/util-common": "^0.2.5"
   },
   "devDependencies": {
     "@flatfile/utils-testing": "^0.0.7",

--- a/plugins/record-hook/src/RecordHook.ts
+++ b/plugins/record-hook/src/RecordHook.ts
@@ -2,7 +2,6 @@ import { Flatfile } from '@flatfile/api'
 import { FlatfileRecord, FlatfileRecords } from '@flatfile/hooks'
 import { FlatfileEvent } from '@flatfile/listener'
 import { asyncBatch } from '@flatfile/util-common'
-import { Effect } from 'effect'
 import { RecordTranslator } from './record.translator'
 
 export interface RecordHookOptions {
@@ -22,22 +21,20 @@ export const RecordHook = async (
   return BulkRecordHook(
     event,
     async (records, event) => {
-      const handlers = await records.map((record: FlatfileRecord) =>
-        Effect.promise(async () => {
-          try {
-            await handler(record, event)
-          } catch (e) {
-            console.error(
-              `An error occurred while running the handler: ${e.message}`
-            )
-          }
-        })
-      )
-      return Effect.runPromise(
-        Effect.all(handlers, {
-          concurrency,
-        })
-      )
+      const promises = new Set<Promise<any>>()
+
+      for (const record of records) {
+        const promise = Promise.resolve(handler(record, event)).finally(() =>
+          promises.delete(promise)
+        )
+        promises.add(promise)
+
+        if (promises.size >= concurrency) {
+          await Promise.race(promises)
+        }
+      }
+
+      return await Promise.all(promises)
     },
     options
   )


### PR DESCRIPTION
This PR replaces the effect library in favor of custom concurrency control in recordHook. No new functionality.