### PR TITLE
feat: update automap's defaultTargetSheet

### DIFF
--- a/.changeset/unlucky-bugs-unite.md
+++ b/.changeset/unlucky-bugs-unite.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-automap': patch
+---
+
+Update defaultTargetSheet return value

--- a/plugins/automap/src/automap.plugin.ts
+++ b/plugins/automap/src/automap.plugin.ts
@@ -29,7 +29,7 @@ export interface AutomapOptions {
   readonly debug?: boolean
   readonly defaultTargetSheet?:
     | string
-    | ((fileName?: string, event?: FlatfileEvent) => string)
+    | ((fileName?: string, event?: FlatfileEvent) => string | Promise<string>)
   readonly matchFilename?: RegExp
   readonly onFailure?: (event: FlatfileEvent) => void
   readonly targetWorkbook?: string


### PR DESCRIPTION
This PR update's automap's defaultTargetSheet return value type to allow it to be an async function

Example usage:
```
listener.use(
  automap({
    accuracy: 'confident',
    targetWorkbook: 'us_wb_123xyz',
    defaultTargetSheet: async (fileName: string) => {
      const { data: workbook }: Flatfile.WorkbookResponse =
        await api.workbooks.get('us_wb_123xyz')

      for (const {
        config: { slug },
      } of workbook.sheets) {
        const regex = new RegExp(`${slug}.csv`)
        if (fileName.match(regex)) {
          return slug
        }
      }
    },
  })
)
```