### PR TITLE
fix: write tmp file to /tmp dir

### DIFF
--- a/.changeset/hungry-pumpkins-explain.md
+++ b/.changeset/hungry-pumpkins-explain.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-export-workbook': patch
+---
+
+Write tmp file to /tmp dir

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -7,6 +7,7 @@ import {
   processRecords,
 } from '@flatfile/util-common'
 import * as fs from 'fs'
+import path from 'path'
 import * as R from 'remeda'
 import * as XLSX from 'xlsx'
 
@@ -153,7 +154,8 @@ export const run = async (
       return
     }
 
-    const fileName = `Workbook-${currentEpoch()}.xlsx`
+    // Lambdas only allow writing to /tmp directory
+    const fileName = path.join('/tmp', `Workbook-${currentEpoch()}.xlsx`)
 
     try {
       XLSX.set_fs(fs)


### PR DESCRIPTION
This PR fixes the `@flatfile/plugin-export-workbook` plugin when deployed by writing to the tmp .xlsx file to `/tmp` dir. Lambdas only allow writing to `/tmp`.

Closes https://github.com/FlatFilers/support-triage/issues/926