### PR TITLE
fix: XML extractor bug fix

### DIFF
--- a/.changeset/twenty-coins-complain.md
+++ b/.changeset/twenty-coins-complain.md
@@ -2,4 +2,4 @@
 '@flatfile/plugin-xml-extractor': patch
 ---
 
-XML extractor bug fix
+This release fixes the `Extractor error: Cannot use 'in' operator to search for '_attributes' in null` bug in the XML extractor exposed with some XML files.

--- a/.changeset/twenty-coins-complain.md
+++ b/.changeset/twenty-coins-complain.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-xml-extractor': patch
+---
+
+XML extractor bug fix

--- a/plugins/xml-extractor/src/parser.ts
+++ b/plugins/xml-extractor/src/parser.ts
@@ -1,6 +1,6 @@
-import toJSON from 'xml-json-format'
 import { WorkbookCapture } from '@flatfile/util-extractor'
 import { mapValues } from 'remeda'
+import toJSON from 'xml-json-format'
 
 export function parseBuffer(
   buffer: Buffer,
@@ -51,7 +51,7 @@ export function headersFromObjectList(
 }
 
 function flattenAttributes(obj: Record<string, any>): Record<string, any> {
-  if ('_attributes' in obj) {
+  if (obj && '_attributes' in obj) {
     const attributes = mapObject(obj._attributes, (k, v) => [`#${k}`, v])
     delete obj._attributes
     return { ...obj, ...attributes }
@@ -76,6 +76,7 @@ function flattenObject(
   prefix = ''
 ): Record<string, any> {
   const obj = flattenAttributes(input)
+  if (!obj) return {}
   const result: Record<string, any> = {}
   Object.keys(obj).forEach((k) => {
     const pre = prefix


### PR DESCRIPTION
This PR is a XML extractor bug fix for `Extractor error: Cannot use 'in' operator to search for '_attributes' in null`

Closes https://github.com/FlatFilers/support-triage/issues/937