### PR TITLE
fix: large XLSX file handling

### DIFF
--- a/.changeset/fair-lions-matter.md
+++ b/.changeset/fair-lions-matter.md
@@ -1,0 +1,8 @@
+---
+'@flatfile/plugin-xlsx-extractor': patch
+'@flatfile/util-extractor': patch
+---
+
+This release fixes several issues related to large Excel file extractions. Previously the SheetJS library would quietly fail when attempting to parse large files. This release turns SheetJS's logging and listens for the ERR_STRING_TOO_LONG which indicates the file is too large to parse. When this occurs, the plugin will now throw an error with a message indicating the file is too large.
+
+Additionally, a bug was fixed where the extraction job was not being immediately acknowledged. This resulted in a message indicating that `no listener has been configured to respond to it`. This has been fixed and the extraction job will now be acknowledged immediately.

--- a/.changeset/fair-lions-matter.md
+++ b/.changeset/fair-lions-matter.md
@@ -6,3 +6,7 @@
 This release fixes several issues related to large Excel file extractions. Previously the SheetJS library would quietly fail when attempting to parse large files. This release turns SheetJS's logging and listens for the ERR_STRING_TOO_LONG which indicates the file is too large to parse. When this occurs, the plugin will now throw an error with a message indicating the file is too large.
 
 Additionally, a bug was fixed where the extraction job was not being immediately acknowledged. This resulted in a message indicating that `no listener has been configured to respond to it`. This has been fixed and the extraction job will now be acknowledged immediately.
+
+A new `dateNF` option has been added to the plugin. This option allows you to specify the date format that should be used when parsing dates from the Excel file.
+
+Finally, the default record insertion chunk size has been decreased from 10,000 to 5,000 to reflect the new default chunk size in the Flatfile Platform.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12678,7 +12678,7 @@
     },
     "plugins/constraints": {
       "name": "@flatfile/plugin-constraints",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.6.5",
@@ -12686,7 +12686,7 @@
         "@flatfile/plugin-record-hook": "^1.3.2"
       },
       "devDependencies": {
-        "@flatfile/utils-testing": "^0.1.1",
+        "@flatfile/utils-testing": "^0.1.2",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -13030,7 +13030,6 @@
       "version": "1.11.0",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.6.3",
         "@flatfile/util-extractor": "^0.5.0",
         "remeda": "^1.14.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"
@@ -13179,7 +13178,7 @@
     },
     "utils/testing": {
       "name": "@flatfile/utils-testing",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.6.3",

--- a/plugins/json-schema/tests/json-schema.e2e.spec.ts
+++ b/plugins/json-schema/tests/json-schema.e2e.spec.ts
@@ -142,5 +142,5 @@ describe('configureSpaceWithJsonSchema() e2e', () => {
     expect(workspaceData.sheets[0].config).toMatchObject(
       expectedWorkbookData.sheets[0].config
     )
-  })
+  }, 15_000)
 })

--- a/plugins/record-hook/src/tests/bulkRecordHook.invalidData.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/bulkRecordHook.invalidData.e2e.spec.ts
@@ -66,5 +66,5 @@ describe('bulkRecordHook() assigns an invalid value and adds an error e2e', () =
     })
 
     expect(errors.length).toBe(records.length)
-  })
+  }, 15_000)
 })

--- a/plugins/record-hook/src/tests/bulkRecordHook.messages.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/bulkRecordHook.messages.e2e.spec.ts
@@ -56,6 +56,6 @@ describe('bulkRecordHook() simple data modification e2e', () => {
         type: 'info',
         message: messageValue,
       })
-    })
+    }, 15_000)
   })
 })

--- a/plugins/record-hook/src/tests/bulkRecordHook.metadata.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/bulkRecordHook.metadata.e2e.spec.ts
@@ -48,6 +48,6 @@ describe('bulkRecordHook() simple data modification e2e', () => {
 
       expect(records[0].metadata).toMatchObject({ test: true })
       expect(records[1].metadata).toMatchObject({ test: true })
-    })
+    }, 15_000)
   })
 })

--- a/plugins/record-hook/src/tests/bulkRecordHook.nochange.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/bulkRecordHook.nochange.e2e.spec.ts
@@ -48,5 +48,5 @@ describe('bulkRecordHook() no data change e2e', () => {
     const logSpy = jest.spyOn(global.console, 'log')
     await listener.waitFor('commit:created')
     expect(logSpy).toHaveBeenCalledWith('No records modified')
-  })
+  }, 15_000)
 })

--- a/plugins/record-hook/src/tests/bulkRecordHook.objectData.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/bulkRecordHook.objectData.e2e.spec.ts
@@ -54,7 +54,7 @@ describe('bulkRecordHook() object data modification e2e', () => {
       await listener.waitFor('commit:created', 2)
       const records = await getRecords(sheetId)
       expect(records[0].valid).toBeTruthy()
-    })
+    }, 15_000)
   })
   describe('Assigns an invalid value to an enum', () => {
     beforeEach(async () => {
@@ -73,6 +73,6 @@ describe('bulkRecordHook() object data modification e2e', () => {
       await listener.waitFor('commit:created', 2)
       const records = await getRecords(sheetId)
       expect(records[1].valid).toBeFalsy()
-    })
+    }, 15_000)
   })
 })

--- a/plugins/record-hook/src/tests/bulkRecordHook.simpleData.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/bulkRecordHook.simpleData.e2e.spec.ts
@@ -75,5 +75,5 @@ describe.each([
 
     expect(records[0].values['alive']).toMatchObject({ value: booleanValue })
     expect(records[1].values['alive']).toMatchObject({ value: booleanValue })
-  })
+  }, 15_000)
 })

--- a/plugins/record-hook/src/tests/bulkRecordHook.throwError.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/bulkRecordHook.throwError.e2e.spec.ts
@@ -58,5 +58,5 @@ describe('bulkRecordHook() throws error e2e', () => {
     expect(logErrorSpy).toHaveBeenCalledWith(
       'An error occurred while running the handler: oops'
     )
-  })
+  }, 15_000)
 })

--- a/plugins/record-hook/src/tests/recordHook.invalidData.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/recordHook.invalidData.e2e.spec.ts
@@ -63,5 +63,5 @@ describe('recordHook() assigns an invalid value and adds an error e2e', () => {
     })
 
     expect(errors.length).toBe(records.length)
-  })
+  }, 15_000)
 })

--- a/plugins/record-hook/src/tests/recordHook.messages.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/recordHook.messages.e2e.spec.ts
@@ -53,6 +53,6 @@ describe('recordHook() simple data modification e2e', () => {
         type: 'info',
         message: messageValue,
       })
-    })
+    }, 15_000)
   })
 })

--- a/plugins/record-hook/src/tests/recordHook.metadata.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/recordHook.metadata.e2e.spec.ts
@@ -46,6 +46,6 @@ describe('recordHook() simple data modification e2e', () => {
 
       expect(records[0].metadata).toMatchObject({ test: true })
       expect(records[1].metadata).toMatchObject({ test: true })
-    })
+    }, 15_000)
   })
 })

--- a/plugins/record-hook/src/tests/recordHook.objectData.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/recordHook.objectData.e2e.spec.ts
@@ -53,7 +53,7 @@ describe('recordHook() object data modification e2e', () => {
       const records = await getRecords(sheetId)
 
       expect(records[0].valid).toBeTruthy()
-    })
+    }, 15_000)
   })
 
   describe('Assigns an invalid value to an enum', () => {
@@ -72,6 +72,6 @@ describe('recordHook() object data modification e2e', () => {
       const records = await getRecords(sheetId)
 
       expect(records[1].valid).toBeFalsy()
-    })
+    }, 15_000)
   })
 })

--- a/plugins/record-hook/src/tests/recordHook.simpleData.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/recordHook.simpleData.e2e.spec.ts
@@ -78,5 +78,5 @@ describe.each([
     expect(records[1].values['alive']).toMatchObject({
       value: booleanValue,
     })
-  })
+  }, 15_000)
 })

--- a/plugins/record-hook/src/tests/recordHook.throwError.e2e.spec.ts
+++ b/plugins/record-hook/src/tests/recordHook.throwError.e2e.spec.ts
@@ -54,5 +54,5 @@ describe('recordHook() throw error e2e', () => {
     expect(logErrorSpy).toHaveBeenCalledWith(
       'An error occurred while running the handler: oops'
     )
-  }, 10_000)
+  }, 15_000)
 })

--- a/plugins/xlsx-extractor/package.json
+++ b/plugins/xlsx-extractor/package.json
@@ -27,7 +27,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.6.3",
     "@flatfile/util-extractor": "^0.5.0",
     "remeda": "^1.14.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.0/xlsx-0.20.0.tgz"

--- a/plugins/xlsx-extractor/src/index.ts
+++ b/plugins/xlsx-extractor/src/index.ts
@@ -17,6 +17,7 @@ export interface ExcelExtractorOptions {
   readonly chunkSize?: number
   readonly parallel?: number
   readonly headerDetectionOptions?: GetHeadersOptions
+  readonly dateNF?: string
   readonly debug?: boolean
 }
 

--- a/plugins/xlsx-extractor/src/index.ts
+++ b/plugins/xlsx-extractor/src/index.ts
@@ -7,17 +7,19 @@ import { parseBuffer } from './parser'
  *
  * @property {boolean} raw - if true, return raw data; if false, return formatted text.
  * @property {boolean} rawNumbers - if true, return raw numbers; if false, return formatted numbers.
+ * @property {string} dateNF - the date format.
  * @property {number} chunkSize - the size of chunk to process when inserting records.
  * @property {number} parallel - the quantity of parallel process when inserting records.
+ * @property {GetHeadersOptions} headerDetectionOptions - the options for header detection.
  * @property {boolean} debug - if true, display helpful console logs.
  */
 export interface ExcelExtractorOptions {
   readonly raw?: boolean
   readonly rawNumbers?: boolean
+  readonly dateNF?: string
   readonly chunkSize?: number
   readonly parallel?: number
   readonly headerDetectionOptions?: GetHeadersOptions
-  readonly dateNF?: string
   readonly debug?: boolean
 }
 

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -10,6 +10,7 @@ export async function parseBuffer(
     raw?: boolean
     rawNumbers?: boolean
     headerDetectionOptions?: GetHeadersOptions
+    dateNF?: string
     debug?: boolean
   }
 ): Promise<WorkbookCapture> {

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -1,4 +1,3 @@
-import { Flatfile } from '@flatfile/api'
 import { SheetCapture, WorkbookCapture } from '@flatfile/util-extractor'
 import { mapKeys, mapValues } from 'remeda'
 import { Readable } from 'stream'
@@ -11,13 +10,36 @@ export async function parseBuffer(
     raw?: boolean
     rawNumbers?: boolean
     headerDetectionOptions?: GetHeadersOptions
+    debug?: boolean
   }
 ): Promise<WorkbookCapture> {
-  const workbook = XLSX.read(buffer, {
-    type: 'buffer',
-    cellDates: true,
-    dense: true,
-  })
+  let workbook: XLSX.WorkBook
+  try {
+    workbook = XLSX.read(buffer, {
+      type: 'buffer',
+      cellDates: true,
+      dense: true,
+      dateNF: options?.dateNF || null,
+      // SheetJS intends the 'WTF' option to be used for development purposes only.
+      // We use it here to specifically capture the ERR_STRING_TOO_LONG error.
+      WTF: true,
+    })
+  } catch (e) {
+    // catch the error if the file is too large to parse, and throw a more helpful error. Otherwise, supress the error.
+    // ref: https://docs.sheetjs.com/docs/miscellany/errors/#invalid-string-length-or-err_string_too_long
+    // i.e. 'Cannot create a string longer than 0x1fffffe8 characters'
+    if (e.code === 'ERR_STRING_TOO_LONG') {
+      if (options?.debug) {
+        console.log(
+          'File is too large to parse. Try converting this file to CSV.'
+        )
+      }
+      throw new Error(
+        'File is too large to parse. Try converting this file to CSV.'
+      )
+    }
+  }
+
   const sheetNames = Object.keys(workbook.Sheets)
   try {
     const processedSheets = (

--- a/plugins/zip-extractor/src/zip.extractor.e2e.spec.ts
+++ b/plugins/zip-extractor/src/zip.extractor.e2e.spec.ts
@@ -40,6 +40,6 @@ describe('ZipExtractor e2e', () => {
       await listener.waitFor('file:created', 4)
       const filesPostUpload = await getFiles(spaceId)
       expect(filesPostUpload.length).toBe(4)
-    }, 15_000)
+    }, 30_000)
   })
 })

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -55,10 +55,6 @@ export const Extractor = (
         }
 
         try {
-          await api.jobs.ack(jobId, {
-            progress: 1,
-            info: 'Excecuting file extraction',
-          })
           await tick(1, 'Retrieving file')
           const { data: file } = await api.files.get(event.context.fileId)
           const buffer = await getFileBuffer(event)


### PR DESCRIPTION
This PR fixes several issues related to large Excel file extractions. Previously the SheetJS library would quietly fail when attempting to parse large files. This release turns SheetJS's logging and listens for the ERR_STRING_TOO_LONG which indicates the file is too large to parse. When this occurs, the plugin will now throw an error with a message indicating the file is too large.

Additionally, a bug was fixed where the extraction job was not being immediately acknowledged. This resulted in a message indicating that `no listener has been configured to respond to it`. This has been fixed and the extraction job will now be acknowledged immediately.

A new `dateNF` option has been added to the plugin. This option allows you to specify the date format that should be used when parsing dates from the Excel file. (The `dateNF` parse option controls interpretation of code 14 [ref](https://github.com/SheetJS/sheetjs/commit/b9bc0a16276376490533559dfe4c4387cfb53b3f))

Finally, the default record insertion chunk size has been decreased from 10,000 to 5,000 to reflect the new default chunk size in the Flatfile Platform.

Guide: https://github.com/FlatFilers/Guides/pull/1087

Closes https://github.com/FlatFilers/support-triage/issues/944