### PR TITLE
chore: update Dedupe deps

### DIFF
--- a/.changeset/calm-pillows-think.md
+++ b/.changeset/calm-pillows-think.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-dedupe': patch
+---
+
+This release updates the dependencies for the @flatfile/plugin-dedupe plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -780,37 +780,34 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "7.6.0",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=6.0.0"
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@flatfile/api": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.6.5.tgz",
-      "integrity": "sha512-YOqOq830fkTLL1UGz2QX4ldSQhcVVy1jDkFlxink2SBNjFOsqrgTw1yF9nyYImp551kyFQnfl9ODWoMpBE3EyA==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.7.1.tgz",
+      "integrity": "sha512-i3GFUmx+j5TNtB81XW9ECpjy0UtAak1y9LmlZWPK5OYZkZ0PUd9eitw+VdzW7GI8+5JqKTNyck5dKzaIyEmZhA==",
       "dependencies": {
         "@flatfile/cross-env-config": "0.0.4",
         "@types/pako": "2.0.1",
-        "@types/qs": "6.9.8",
-        "@types/url-join": "4.0.1",
-        "axios": "0.27.2",
         "form-data": "4.0.0",
         "js-base64": "3.7.2",
+        "node-fetch": "2.7.0",
         "pako": "2.0.1",
         "qs": "6.11.2",
         "url-join": "4.0.1"
-      }
-    },
-    "node_modules/@flatfile/api/node_modules/axios": {
-      "version": "0.27.2",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
       }
     },
     "node_modules/@flatfile/blueprint": {
@@ -10182,8 +10179,9 @@
       }
     },
     "node_modules/remeda": {
-      "version": "1.37.0",
-      "license": "MIT"
+      "version": "1.40.2",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.40.2.tgz",
+      "integrity": "sha512-rD5Qe5OacbxWJovOdTB/ttGnQAUyYjrpwKDkd3Tl8+GUkk6k3AUgpfLMD6PeOV5P+FNaETw3bIHCgtd+4coeNA=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -11967,7 +11965,7 @@
     },
     "plugins/constraints": {
       "name": "@flatfile/plugin-constraints",
-      "version": "1.1.2",
+      "version": "1.1.4",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.6.5",
@@ -11991,17 +11989,37 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/api": "^1.6.3",
-        "@flatfile/listener": "^1.0.0",
-        "remeda": "^1.14.0",
+        "@flatfile/api": "^1.7.1",
+        "@flatfile/listener": "^1.0.1",
+        "remeda": "^1.40.2",
         "ts-pattern": "^5.0.4"
       },
       "devDependencies": {
-        "@faker-js/faker": "^7.6.0"
+        "@faker-js/faker": "^8.4.1"
       },
       "engines": {
         "node": ">= 16"
       }
+    },
+    "plugins/dedupe/node_modules/@flatfile/listener": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@flatfile/listener/-/listener-1.0.1.tgz",
+      "integrity": "sha512-XClO1KhQDL9Q7zfTANcMeole7Q/2QaIhzttZI+p04PjB+bUlIvk+yUbHvhnLahNkvLHRoIth4p+oBj8tPC1cxA==",
+      "dependencies": {
+        "ansi-colors": "^4.1.3",
+        "cross-fetch": "^4.0.0",
+        "flat": "^5.0.2",
+        "pako": "^2.1.0",
+        "wildcard-match": "^5.1.2"
+      },
+      "peerDependencies": {
+        "@flatfile/api": "^1.5.10"
+      }
+    },
+    "plugins/dedupe/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",

--- a/plugins/dedupe/package.json
+++ b/plugins/dedupe/package.json
@@ -27,12 +27,12 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/api": "^1.6.3",
-    "@flatfile/listener": "^1.0.0",
-    "remeda": "^1.14.0",
+    "@flatfile/api": "^1.7.1",
+    "@flatfile/listener": "^1.0.1",
+    "remeda": "^1.40.2",
     "ts-pattern": "^5.0.4"
   },
   "devDependencies": {
-    "@faker-js/faker": "^7.6.0"
+    "@faker-js/faker": "^8.4.1"
   }
 }


### PR DESCRIPTION
This PR updates the dependencies for the `@flatfile/plugin-dedupe` plugin

Closes https://github.com/FlatFilers/support-triage/issues/1024