### PR TITLE
fix: excel worksheet names

### DIFF
--- a/.changeset/popular-pumas-fry.md
+++ b/.changeset/popular-pumas-fry.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-export-workbook': patch
+---
+
+Excel places size and character limitations on worksheet names. This release strips invalid characters from the sheet name.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1935,9 +1935,8 @@
     },
     "node_modules/@parcel/bundler-default": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/bundler-default/-/bundler-default-2.12.0.tgz",
-      "integrity": "sha512-3ybN74oYNMKyjD6V20c9Gerdbh7teeNvVMwIoHIQMzuIFT6IGX53PyOLlOKRLbjxMc0TMimQQxIt2eQqxR5LsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/graph": "3.2.0",
@@ -1957,9 +1956,8 @@
     },
     "node_modules/@parcel/cache": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/cache/-/cache-2.12.0.tgz",
-      "integrity": "sha512-FX5ZpTEkxvq/yvWklRHDESVRz+c7sLTXgFuzz6uEnBcXV38j6dMSikflNpHA6q/L4GKkCqRywm9R6XQwhwIMyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/fs": "2.12.0",
         "@parcel/logger": "2.12.0",
@@ -1979,9 +1977,8 @@
     },
     "node_modules/@parcel/codeframe": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/codeframe/-/codeframe-2.12.0.tgz",
-      "integrity": "sha512-v2VmneILFiHZJTxPiR7GEF1wey1/IXPdZMcUlNXBiPZyWDfcuNgGGVQkx/xW561rULLIvDPharOMdxz5oHOKQg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0"
       },
@@ -1995,9 +1992,8 @@
     },
     "node_modules/@parcel/codeframe/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2010,9 +2006,8 @@
     },
     "node_modules/@parcel/codeframe/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2026,9 +2021,8 @@
     },
     "node_modules/@parcel/codeframe/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2038,24 +2032,21 @@
     },
     "node_modules/@parcel/codeframe/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/codeframe/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@parcel/codeframe/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2065,9 +2056,8 @@
     },
     "node_modules/@parcel/compressor-raw": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/compressor-raw/-/compressor-raw-2.12.0.tgz",
-      "integrity": "sha512-h41Q3X7ZAQ9wbQ2csP8QGrwepasLZdXiuEdpUryDce6rF9ZiHoJ97MRpdLxOhOPyASTw/xDgE1xyaPQr0Q3f5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0"
       },
@@ -2082,9 +2072,8 @@
     },
     "node_modules/@parcel/config-default": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/config-default/-/config-default-2.12.0.tgz",
-      "integrity": "sha512-dPNe2n9eEsKRc1soWIY0yToMUPirPIa2QhxcCB3Z5RjpDGIXm0pds+BaiqY6uGLEEzsjhRO0ujd4v2Rmm0vuFg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/bundler-default": "2.12.0",
         "@parcel/compressor-raw": "2.12.0",
@@ -2128,9 +2117,8 @@
     },
     "node_modules/@parcel/core": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.12.0.tgz",
-      "integrity": "sha512-s+6pwEj+GfKf7vqGUzN9iSEPueUssCCQrCBUlcAfKrJe0a22hTUCjewpB0I7lNrCIULt8dkndD+sMdOrXsRl6Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/cache": "2.12.0",
@@ -2181,9 +2169,8 @@
     },
     "node_modules/@parcel/diagnostic": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.12.0.tgz",
-      "integrity": "sha512-8f1NOsSFK+F4AwFCKynyIu9Kr/uWHC+SywAv4oS6Bv3Acig0gtwUjugk0C9UaB8ztBZiW5TQZhw+uPZn9T/lJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "nullthrows": "^1.1.1"
@@ -2198,9 +2185,8 @@
     },
     "node_modules/@parcel/events": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/events/-/events-2.12.0.tgz",
-      "integrity": "sha512-nmAAEIKLjW1kB2cUbCYSmZOGbnGj8wCzhqnK727zCCWaA25ogzAtt657GPOeFyqW77KyosU728Tl63Fc8hphIA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2211,9 +2197,8 @@
     },
     "node_modules/@parcel/fs": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/fs/-/fs-2.12.0.tgz",
-      "integrity": "sha512-NnFkuvou1YBtPOhTdZr44WN7I60cGyly2wpHzqRl62yhObyi1KvW0SjwOMa0QGNcBOIzp4G0CapoZ93hD0RG5Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/rust": "2.12.0",
         "@parcel/types": "2.12.0",
@@ -2234,9 +2219,8 @@
     },
     "node_modules/@parcel/graph": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@parcel/graph/-/graph-3.2.0.tgz",
-      "integrity": "sha512-xlrmCPqy58D4Fg5umV7bpwDx5Vyt7MlnQPxW68vae5+BA4GSWetfZt+Cs5dtotMG2oCHzZxhIPt7YZ7NRyQzLA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nullthrows": "^1.1.1"
       },
@@ -2250,9 +2234,8 @@
     },
     "node_modules/@parcel/logger": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/logger/-/logger-2.12.0.tgz",
-      "integrity": "sha512-cJ7Paqa7/9VJ7C+KwgJlwMqTQBOjjn71FbKk0G07hydUEBISU2aDfmc/52o60ErL9l+vXB26zTrIBanbxS8rVg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/events": "2.12.0"
@@ -2267,9 +2250,8 @@
     },
     "node_modules/@parcel/markdown-ansi": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/markdown-ansi/-/markdown-ansi-2.12.0.tgz",
-      "integrity": "sha512-WZz3rzL8k0H3WR4qTHX6Ic8DlEs17keO9gtD4MNGyMNQbqQEvQ61lWJaIH0nAtgEetu0SOITiVqdZrb8zx/M7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0"
       },
@@ -2283,9 +2265,8 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2298,9 +2279,8 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2314,9 +2294,8 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2326,24 +2305,21 @@
     },
     "node_modules/@parcel/markdown-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/markdown-ansi/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@parcel/markdown-ansi/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2353,9 +2329,8 @@
     },
     "node_modules/@parcel/namer-default": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/namer-default/-/namer-default-2.12.0.tgz",
-      "integrity": "sha512-9DNKPDHWgMnMtqqZIMiEj/R9PNWW16lpnlHjwK3ciRlMPgjPJ8+UNc255teZODhX0T17GOzPdGbU/O/xbxVPzA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -2372,9 +2347,8 @@
     },
     "node_modules/@parcel/node-resolver-core": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@parcel/node-resolver-core/-/node-resolver-core-3.3.0.tgz",
-      "integrity": "sha512-rhPW9DYPEIqQBSlYzz3S0AjXxjN6Ub2yS6tzzsW/4S3Gpsgk/uEq4ZfxPvoPf/6TgZndVxmKwpmxaKtGMmf3cA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/diagnostic": "2.12.0",
@@ -2394,9 +2368,8 @@
     },
     "node_modules/@parcel/optimizer-css": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.12.0.tgz",
-      "integrity": "sha512-ifbcC97fRzpruTjaa8axIFeX4MjjSIlQfem3EJug3L2AVqQUXnM1XO8L0NaXGNLTW2qnh1ZjIJ7vXT/QhsphsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -2417,9 +2390,8 @@
     },
     "node_modules/@parcel/optimizer-htmlnano": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-htmlnano/-/optimizer-htmlnano-2.12.0.tgz",
-      "integrity": "sha512-MfPMeCrT8FYiOrpFHVR+NcZQlXAptK2r4nGJjfT+ndPBhEEZp4yyL7n1y7HfX9geg5altc4WTb4Gug7rCoW8VQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "htmlnano": "^2.0.0",
@@ -2438,9 +2410,8 @@
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/css-select": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.0.1",
@@ -2454,9 +2425,8 @@
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/css-tree": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
@@ -2467,9 +2437,8 @@
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/csso": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "css-tree": "^1.1.2"
       },
@@ -2479,15 +2448,13 @@
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/mdn-data": {
       "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@parcel/optimizer-htmlnano/node_modules/svgo": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
@@ -2506,9 +2473,8 @@
     },
     "node_modules/@parcel/optimizer-image": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-image/-/optimizer-image-2.12.0.tgz",
-      "integrity": "sha512-bo1O7raeAIbRU5nmNVtx8divLW9Xqn0c57GVNGeAK4mygnQoqHqRZ0mR9uboh64pxv6ijXZHPhKvU9HEpjPjBQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -2530,9 +2496,8 @@
     },
     "node_modules/@parcel/optimizer-svgo": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-svgo/-/optimizer-svgo-2.12.0.tgz",
-      "integrity": "sha512-Kyli+ZZXnoonnbeRQdoWwee9Bk2jm/49xvnfb+2OO8NN0d41lblBoRhOyFiScRnJrw7eVl1Xrz7NTkXCIO7XFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -2550,9 +2515,8 @@
     },
     "node_modules/@parcel/optimizer-svgo/node_modules/css-select": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
         "css-what": "^6.0.1",
@@ -2566,9 +2530,8 @@
     },
     "node_modules/@parcel/optimizer-svgo/node_modules/css-tree": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
@@ -2579,9 +2542,8 @@
     },
     "node_modules/@parcel/optimizer-svgo/node_modules/csso": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-4.2.0.tgz",
-      "integrity": "sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "css-tree": "^1.1.2"
       },
@@ -2591,15 +2553,13 @@
     },
     "node_modules/@parcel/optimizer-svgo/node_modules/mdn-data": {
       "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@parcel/optimizer-svgo/node_modules/svgo": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
-      "integrity": "sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@trysound/sax": "0.2.0",
         "commander": "^7.2.0",
@@ -2618,9 +2578,8 @@
     },
     "node_modules/@parcel/optimizer-swc": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/optimizer-swc/-/optimizer-swc-2.12.0.tgz",
-      "integrity": "sha512-iBi6LZB3lm6WmbXfzi8J3DCVPmn4FN2lw7DGXxUXu7MouDPVWfTsM6U/5TkSHJRNRogZ2gqy5q9g34NPxHbJcw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -2640,9 +2599,8 @@
     },
     "node_modules/@parcel/package-manager": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/package-manager/-/package-manager-2.12.0.tgz",
-      "integrity": "sha512-0nvAezcjPx9FT+hIL+LS1jb0aohwLZXct7jAh7i0MLMtehOi0z1Sau+QpgMlA9rfEZZ1LIeFdnZZwqSy7Ccspw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/fs": "2.12.0",
@@ -2667,9 +2625,8 @@
     },
     "node_modules/@parcel/packager-css": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-css/-/packager-css-2.12.0.tgz",
-      "integrity": "sha512-j3a/ODciaNKD19IYdWJT+TP+tnhhn5koBGBWWtrKSu0UxWpnezIGZetit3eE+Y9+NTePalMkvpIlit2eDhvfJA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -2689,9 +2646,8 @@
     },
     "node_modules/@parcel/packager-html": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-html/-/packager-html-2.12.0.tgz",
-      "integrity": "sha512-PpvGB9hFFe+19NXGz2ApvPrkA9GwEqaDAninT+3pJD57OVBaxB8U+HN4a5LICKxjUppPPqmrLb6YPbD65IX4RA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/types": "2.12.0",
@@ -2710,9 +2666,8 @@
     },
     "node_modules/@parcel/packager-js": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-js/-/packager-js-2.12.0.tgz",
-      "integrity": "sha512-viMF+FszITRRr8+2iJyk+4ruGiL27Y6AF7hQ3xbJfzqnmbOhGFtLTQwuwhOLqN/mWR2VKdgbLpZSarWaO3yAMg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -2734,9 +2689,8 @@
     },
     "node_modules/@parcel/packager-js/node_modules/globals": {
       "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "type-fest": "^0.20.2"
       },
@@ -2749,9 +2703,8 @@
     },
     "node_modules/@parcel/packager-js/node_modules/type-fest": {
       "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true,
+      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -2761,9 +2714,8 @@
     },
     "node_modules/@parcel/packager-raw": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-raw/-/packager-raw-2.12.0.tgz",
-      "integrity": "sha512-tJZqFbHqP24aq1F+OojFbQIc09P/u8HAW5xfndCrFnXpW4wTgM3p03P0xfw3gnNq+TtxHJ8c3UFE5LnXNNKhYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0"
       },
@@ -2778,9 +2730,8 @@
     },
     "node_modules/@parcel/packager-svg": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-svg/-/packager-svg-2.12.0.tgz",
-      "integrity": "sha512-ldaGiacGb2lLqcXas97k8JiZRbAnNREmcvoY2W2dvW4loVuDT9B9fU777mbV6zODpcgcHWsLL3lYbJ5Lt3y9cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/types": "2.12.0",
@@ -2798,9 +2749,8 @@
     },
     "node_modules/@parcel/packager-ts": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-ts/-/packager-ts-2.12.0.tgz",
-      "integrity": "sha512-8wR0BNN2NBD+IIU0tjioK+lRD4p2Qi/fKxDH5ixEW912tRV+Vd4kE8k++U6YQIpSlK4FRnjFod5zYYhNSLuiXg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0"
       },
@@ -2815,9 +2765,8 @@
     },
     "node_modules/@parcel/packager-wasm": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/packager-wasm/-/packager-wasm-2.12.0.tgz",
-      "integrity": "sha512-fYqZzIqO9fGYveeImzF8ll6KRo2LrOXfD+2Y5U3BiX/wp9wv17dz50QLDQm9hmTcKGWxK4yWqKQh+Evp/fae7A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0"
       },
@@ -2832,9 +2781,8 @@
     },
     "node_modules/@parcel/plugin": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/plugin/-/plugin-2.12.0.tgz",
-      "integrity": "sha512-nc/uRA8DiMoe4neBbzV6kDndh/58a4wQuGKw5oEoIwBCHUvE2W8ZFSu7ollSXUGRzfacTt4NdY8TwS73ScWZ+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/types": "2.12.0"
       },
@@ -2848,9 +2796,8 @@
     },
     "node_modules/@parcel/profiler": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/profiler/-/profiler-2.12.0.tgz",
-      "integrity": "sha512-q53fvl5LDcFYzMUtSusUBZSjQrKjMlLEBgKeQHFwkimwR1mgoseaDBDuNz0XvmzDzF1UelJ02TUKCGacU8W2qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/events": "2.12.0",
@@ -2866,9 +2813,8 @@
     },
     "node_modules/@parcel/reporter-cli": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-cli/-/reporter-cli-2.12.0.tgz",
-      "integrity": "sha512-TqKsH4GVOLPSCanZ6tcTPj+rdVHERnt5y4bwTM82cajM21bCX1Ruwp8xOKU+03091oV2pv5ieB18pJyRF7IpIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/types": "2.12.0",
@@ -2887,9 +2833,8 @@
     },
     "node_modules/@parcel/reporter-cli/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2902,9 +2847,8 @@
     },
     "node_modules/@parcel/reporter-cli/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2918,9 +2862,8 @@
     },
     "node_modules/@parcel/reporter-cli/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2930,24 +2873,21 @@
     },
     "node_modules/@parcel/reporter-cli/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/reporter-cli/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@parcel/reporter-cli/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2957,9 +2897,8 @@
     },
     "node_modules/@parcel/reporter-dev-server": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-dev-server/-/reporter-dev-server-2.12.0.tgz",
-      "integrity": "sha512-tIcDqRvAPAttRlTV28dHcbWT5K2r/MBFks7nM4nrEDHWtnrCwimkDmZTc1kD8QOCCjGVwRHcQybpHvxfwol6GA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0"
@@ -2975,9 +2914,8 @@
     },
     "node_modules/@parcel/reporter-tracer": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/reporter-tracer/-/reporter-tracer-2.12.0.tgz",
-      "integrity": "sha512-g8rlu9GxB8Ut/F8WGx4zidIPQ4pcYFjU9bZO+fyRIPrSUFH2bKijCnbZcr4ntqzDGx74hwD6cCG4DBoleq2UlQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0",
@@ -2995,9 +2933,8 @@
     },
     "node_modules/@parcel/resolver-default": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/resolver-default/-/resolver-default-2.12.0.tgz",
-      "integrity": "sha512-uuhbajTax37TwCxu7V98JtRLiT6hzE4VYSu5B7Qkauy14/WFt2dz6GOUXPgVsED569/hkxebPx3KCMtZW6cHHA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/node-resolver-core": "3.3.0",
         "@parcel/plugin": "2.12.0"
@@ -3013,9 +2950,8 @@
     },
     "node_modules/@parcel/runtime-browser-hmr": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-browser-hmr/-/runtime-browser-hmr-2.12.0.tgz",
-      "integrity": "sha512-4ZLp2FWyD32r0GlTulO3+jxgsA3oO1P1b5oO2IWuWilfhcJH5LTiazpL5YdusUjtNn9PGN6QLAWfxmzRIfM+Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0"
@@ -3031,9 +2967,8 @@
     },
     "node_modules/@parcel/runtime-js": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-js/-/runtime-js-2.12.0.tgz",
-      "integrity": "sha512-sBerP32Z1crX5PfLNGDSXSdqzlllM++GVnVQVeM7DgMKS8JIFG3VLi28YkX+dYYGtPypm01JoIHCkvwiZEcQJg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3051,9 +2986,8 @@
     },
     "node_modules/@parcel/runtime-react-refresh": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-react-refresh/-/runtime-react-refresh-2.12.0.tgz",
-      "integrity": "sha512-SCHkcczJIDFTFdLTzrHTkQ0aTrX3xH6jrA4UsCBL6ji61+w+ohy4jEEe9qCgJVXhnJfGLE43HNXek+0MStX+Mw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0",
@@ -3071,9 +3005,8 @@
     },
     "node_modules/@parcel/runtime-service-worker": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/runtime-service-worker/-/runtime-service-worker-2.12.0.tgz",
-      "integrity": "sha512-BXuMBsfiwpIEnssn+jqfC3jkgbS8oxeo3C7xhSQsuSv+AF2FwY3O3AO1c1RBskEW3XrBLNINOJujroNw80VTKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0",
@@ -3090,9 +3023,8 @@
     },
     "node_modules/@parcel/rust": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/rust/-/rust-2.12.0.tgz",
-      "integrity": "sha512-005cldMdFZFDPOjbDVEXcINQ3wT4vrxvSavRWI3Az0e3E18exO/x/mW9f648KtXugOXMAqCEqhFHcXECL9nmMw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3114,9 +3046,8 @@
     },
     "node_modules/@parcel/transformer-babel": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-babel/-/transformer-babel-2.12.0.tgz",
-      "integrity": "sha512-zQaBfOnf/l8rPxYGnsk/ufh/0EuqvmnxafjBIpKZ//j6rGylw5JCqXSb1QvvAqRYruKeccxGv7+HrxpqKU6V4A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3138,9 +3069,8 @@
     },
     "node_modules/@parcel/transformer-css": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.12.0.tgz",
-      "integrity": "sha512-vXhOqoAlQGATYyQ433Z1DXKmiKmzOAUmKysbYH3FD+LKEKLMEl/pA14goqp00TW+A/EjtSKKyeMyHlMIIUqj4Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3161,9 +3091,8 @@
     },
     "node_modules/@parcel/transformer-html": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-html/-/transformer-html-2.12.0.tgz",
-      "integrity": "sha512-5jW4dFFBlYBvIQk4nrH62rfA/G/KzVzEDa6S+Nne0xXhglLjkm64Ci9b/d4tKZfuGWUbpm2ASAq8skti/nfpXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3186,9 +3115,8 @@
     },
     "node_modules/@parcel/transformer-image": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-image/-/transformer-image-2.12.0.tgz",
-      "integrity": "sha512-8hXrGm2IRII49R7lZ0RpmNk27EhcsH+uNKsvxuMpXPuEnWgC/ha/IrjaI29xCng1uGur74bJF43NUSQhR4aTdw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0",
@@ -3205,9 +3133,8 @@
     },
     "node_modules/@parcel/transformer-js": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-js/-/transformer-js-2.12.0.tgz",
-      "integrity": "sha512-OSZpOu+FGDbC/xivu24v092D9w6EGytB3vidwbdiJ2FaPgfV7rxS0WIUjH4I0OcvHAcitArRXL0a3+HrNTdQQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3235,15 +3162,13 @@
     },
     "node_modules/@parcel/transformer-js/node_modules/regenerator-runtime": {
       "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/transformer-json": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-json/-/transformer-json-2.12.0.tgz",
-      "integrity": "sha512-Utv64GLRCQILK5r0KFs4o7I41ixMPllwOLOhkdjJKvf1hZmN6WqfOmB1YLbWS/y5Zb/iB52DU2pWZm96vLFQZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "json5": "^2.2.0"
@@ -3259,9 +3184,8 @@
     },
     "node_modules/@parcel/transformer-postcss": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-postcss/-/transformer-postcss-2.12.0.tgz",
-      "integrity": "sha512-FZqn+oUtiLfPOn67EZxPpBkfdFiTnF4iwiXPqvst3XI8H+iC+yNgzmtJkunOOuylpYY6NOU5jT8d7saqWSDv2Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3283,9 +3207,8 @@
     },
     "node_modules/@parcel/transformer-posthtml": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.12.0.tgz",
-      "integrity": "sha512-z6Z7rav/pcaWdeD+2sDUcd0mmNZRUvtHaUGa50Y2mr+poxrKilpsnFMSiWBT+oOqPt7j71jzDvrdnAF4XkCljg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0",
@@ -3306,9 +3229,8 @@
     },
     "node_modules/@parcel/transformer-raw": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-raw/-/transformer-raw-2.12.0.tgz",
-      "integrity": "sha512-Ht1fQvXxix0NncdnmnXZsa6hra20RXYh1VqhBYZLsDfkvGGFnXIgO03Jqn4Z8MkKoa0tiNbDhpKIeTjyclbBxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0"
       },
@@ -3323,9 +3245,8 @@
     },
     "node_modules/@parcel/transformer-react-refresh-wrap": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-react-refresh-wrap/-/transformer-react-refresh-wrap-2.12.0.tgz",
-      "integrity": "sha512-GE8gmP2AZtkpBIV5vSCVhewgOFRhqwdM5Q9jNPOY5PKcM3/Ff0qCqDiTzzGLhk0/VMBrdjssrfZkVx6S/lHdJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/plugin": "2.12.0",
         "@parcel/utils": "2.12.0",
@@ -3342,9 +3263,8 @@
     },
     "node_modules/@parcel/transformer-svg": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-svg/-/transformer-svg-2.12.0.tgz",
-      "integrity": "sha512-cZJqGRJ4JNdYcb+vj94J7PdOuTnwyy45dM9xqbIMH+HSiiIkfrMsdEwYft0GTyFTdsnf+hdHn3tau7Qa5hhX+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3366,9 +3286,8 @@
     },
     "node_modules/@parcel/transformer-typescript-types": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/transformer-typescript-types/-/transformer-typescript-types-2.12.0.tgz",
-      "integrity": "sha512-uxF4UBMYvbjiV3zHTWMrZX8cFD92VUvD3ArcGi5WEtuVROUm9Sc47o0mOzxKfMFlJu2KOfZVHYlzK9f/UKA2kQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/plugin": "2.12.0",
@@ -3391,9 +3310,8 @@
     },
     "node_modules/@parcel/ts-utils": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/ts-utils/-/ts-utils-2.12.0.tgz",
-      "integrity": "sha512-zou+W6dcqnXXUOfN5zGM+ePIWbYOhGp8bVB2jICoNkoKmNAHd4l4zeHl5yQXnbZfynVw88cZVqxtXS8tYebelg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "nullthrows": "^1.1.1"
       },
@@ -3410,9 +3328,8 @@
     },
     "node_modules/@parcel/types": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/types/-/types-2.12.0.tgz",
-      "integrity": "sha512-8zAFiYNCwNTQcglIObyNwKfRYQK5ELlL13GuBOrSMxueUiI5ylgsGbTS1N7J3dAGZixHO8KhHGv5a71FILn9rQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/cache": "2.12.0",
         "@parcel/diagnostic": "2.12.0",
@@ -3425,9 +3342,8 @@
     },
     "node_modules/@parcel/utils": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/utils/-/utils-2.12.0.tgz",
-      "integrity": "sha512-z1JhLuZ8QmDaYoEIuUCVZlhcFrS7LMfHrb2OCRui5SQFntRWBH2fNM6H/fXXUkT9SkxcuFP2DUA6/m4+Gkz72g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/codeframe": "2.12.0",
         "@parcel/diagnostic": "2.12.0",
@@ -3448,9 +3364,8 @@
     },
     "node_modules/@parcel/utils/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -3463,9 +3378,8 @@
     },
     "node_modules/@parcel/utils/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -3479,9 +3393,8 @@
     },
     "node_modules/@parcel/utils/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -3491,24 +3404,21 @@
     },
     "node_modules/@parcel/utils/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@parcel/utils/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@parcel/utils/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -3808,9 +3718,8 @@
     },
     "node_modules/@parcel/workers": {
       "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@parcel/workers/-/workers-2.12.0.tgz",
-      "integrity": "sha512-zv5We5Jmb+ZWXlU6A+AufyjY4oZckkxsZ8J4dvyWL0W8IQvGO1JB4FGeryyttzQv3RM3OxcN/BpTGPiDG6keBw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@parcel/diagnostic": "2.12.0",
         "@parcel/logger": "2.12.0",
@@ -4088,9 +3997,8 @@
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10.13.0"
       }
@@ -4813,9 +4721,8 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.1",
@@ -5190,9 +5097,8 @@
     },
     "node_modules/commander": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
@@ -5254,9 +5160,8 @@
     },
     "node_modules/cosmiconfig": {
       "version": "8.3.6",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.3.0",
         "js-yaml": "^4.1.0",
@@ -5280,15 +5185,13 @@
     },
     "node_modules/cosmiconfig/node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5401,9 +5304,8 @@
     },
     "node_modules/css-select": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5419,9 +5321,8 @@
     },
     "node_modules/css-select/node_modules/dom-serializer": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5435,9 +5336,8 @@
     },
     "node_modules/css-select/node_modules/domhandler": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5452,9 +5352,8 @@
     },
     "node_modules/css-select/node_modules/domutils": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5468,9 +5367,8 @@
     },
     "node_modules/css-select/node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "optional": true,
       "peer": true,
       "engines": {
@@ -5482,9 +5380,8 @@
     },
     "node_modules/css-tree": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5497,9 +5394,8 @@
     },
     "node_modules/css-what": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">= 6"
       },
@@ -5509,9 +5405,8 @@
     },
     "node_modules/csso": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5524,9 +5419,8 @@
     },
     "node_modules/csso/node_modules/css-tree": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -5540,9 +5434,8 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "dev": true,
+      "license": "CC0-1.0",
       "optional": true,
       "peer": true
     },
@@ -5809,9 +5702,8 @@
     },
     "node_modules/dom-serializer": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -5823,30 +5715,27 @@
     },
     "node_modules/dom-serializer/node_modules/entities": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/fb55"
         }
-      ]
+      ],
+      "license": "BSD-2-Clause"
     },
     "node_modules/domhandler": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -5859,9 +5748,8 @@
     },
     "node_modules/domutils": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -5958,9 +5846,8 @@
     },
     "node_modules/entities": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -7127,9 +7014,8 @@
     },
     "node_modules/htmlnano": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.0.tgz",
-      "integrity": "sha512-jVGRE0Ep9byMBKEu0Vxgl8dhXYOUk0iNQ2pjsG+BcRB0u0oDF5A9p/iBGMg/PGKYUyMD0OAGu8dVT5Lzj8S58g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cosmiconfig": "^8.0.0",
         "posthtml": "^0.16.5",
@@ -7174,8 +7060,6 @@
     },
     "node_modules/htmlparser2": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -7184,6 +7068,7 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.2",
@@ -7323,9 +7208,8 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -7339,9 +7223,8 @@
     },
     "node_modules/import-fresh/node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -7601,9 +7484,8 @@
     },
     "node_modules/is-json": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/is-module": {
       "version": "1.0.0",
@@ -9526,9 +9408,8 @@
     },
     "node_modules/lightningcss": {
       "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.24.0.tgz",
-      "integrity": "sha512-y36QEEDVx4IM7/yIZNsZJMRREIu26WzTsauIysf5s76YeCmlSbRZS7aC97IGPuoFRnyZ5Wx43OBsQBFB5Ne7ng==",
       "dev": true,
+      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -9553,175 +9434,14 @@
     },
     "node_modules/lightningcss-darwin-arm64": {
       "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.24.0.tgz",
-      "integrity": "sha512-rTNPkEiynOu4CfGdd5ZfVOQe2gd2idfQd4EfX1l2ZUUwd+2SwSdbb7cG4rlwfnZckbzCAygm85xkpekRE5/wFw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.24.0.tgz",
-      "integrity": "sha512-4KCeF2RJjzp9xdGY8zIH68CUtptEg8uz8PfkHvsIdrP4t9t5CIgfDBhiB8AmuO75N6SofdmZexDZIKdy9vA7Ww==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.24.0.tgz",
-      "integrity": "sha512-FJAYlek1wXuVTsncNU0C6YD41q126dXcIUm97KAccMn9C4s/JfLSqGWT2gIzAblavPFkyGG2gIADTWp3uWfN1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.24.0.tgz",
-      "integrity": "sha512-N55K6JqzMx7C0hYUu1YmWqhkHwzEJlkQRMA6phY65noO0I1LOAvP4wBIoFWrzRE+O6zL0RmXJ2xppqyTbk3sYw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.24.0.tgz",
-      "integrity": "sha512-MqqUB2TpYtFWeBvvf5KExDdClU3YGLW5bHKs50uKKootcvG9KoS7wYwd5UichS+W3mYLc5yXUPGD1DNWbLiYKw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.24.0.tgz",
-      "integrity": "sha512-5wn4d9tFwa5bS1ao9mLexYVJdh3nn09HNIipsII6ZF7z9ZA5J4dOEhMgKoeCl891axTGTUYd8Kxn+Hn3XUSYRQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.24.0.tgz",
-      "integrity": "sha512-3j5MdTh+LSDF3o6uDwRjRUgw4J+IfDCVtdkUrJvKxL79qBLUujXY7CTe5X3IQDDLKEe/3wu49r8JKgxr0MfjbQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.24.0.tgz",
-      "integrity": "sha512-HI+rNnvaLz0o36z6Ki0gyG5igVGrJmzczxA5fznr6eFTj3cHORoR/j2q8ivMzNFR4UKJDkTWUH5LMhacwOHWBA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.24.0.tgz",
-      "integrity": "sha512-oeije/t7OZ5N9vSs6amyW/34wIYoBCpE6HUlsSKcP2SR1CVgx9oKEM00GtQmtqNnYiMIfsSm7+ppMb4NLtD5vg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">= 12.0.0"
@@ -9961,9 +9681,8 @@
     },
     "node_modules/mdn-data": {
       "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true,
+      "license": "CC0-1.0",
       "optional": true,
       "peer": true
     },
@@ -10351,9 +10070,8 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0"
       },
@@ -10802,9 +10520,8 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -10964,15 +10681,13 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/posthtml": {
       "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
-      "integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "posthtml-parser": "^0.11.0",
         "posthtml-render": "^3.0.0"
@@ -10983,9 +10698,8 @@
     },
     "node_modules/posthtml-parser": {
       "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.10.2.tgz",
-      "integrity": "sha512-PId6zZ/2lyJi9LiKfe+i2xv57oEjJgWbsHGGANwos5AvdQp98i6AtamAl8gzSVFGfQ43Glb5D614cvZf012VKg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "htmlparser2": "^7.1.1"
       },
@@ -10995,9 +10709,8 @@
     },
     "node_modules/posthtml-render": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-json": "^2.0.1"
       },
@@ -11007,9 +10720,8 @@
     },
     "node_modules/posthtml/node_modules/posthtml-parser": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
-      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "htmlparser2": "^7.1.1"
       },
@@ -11367,9 +11079,8 @@
     },
     "node_modules/react-error-overlay": {
       "version": "6.0.9",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
-      "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-is": {
       "version": "18.2.0",
@@ -11377,9 +11088,8 @@
     },
     "node_modules/react-refresh": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.9.0.tgz",
-      "integrity": "sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12207,9 +11917,8 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "optional": true,
       "peer": true,
       "engines": {
@@ -12334,9 +12043,8 @@
     },
     "node_modules/srcset": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
-      "integrity": "sha512-wvLeHgcVHKO8Sc/H/5lkGreJQVeYMm9rlmt8PuR1xE31rIuXhuzznUUqAt8MqLhB3MqJdFzlNAfpcWnxiFUcPw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -12346,10 +12054,8 @@
     },
     "node_modules/stable": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
-      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -12658,9 +12364,8 @@
     },
     "node_modules/svgo": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
-      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
@@ -12803,9 +12508,8 @@
     },
     "node_modules/timsort": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.0.33",

--- a/plugins/export-workbook/src/index.ts
+++ b/plugins/export-workbook/src/index.ts
@@ -1,19 +1,15 @@
 import { FlatfileListener } from '@flatfile/listener'
-import { PluginOptions, run } from './plugin'
+import { PluginOptions, exportRecords } from './plugin'
 
 /**
- * Workbook export plugin for Flatfile.
+ * Export records plugin for Flatfile.
  *
  * @param opts - plugin config options
  */
-export const exportWorkbookPlugin = (opts: PluginOptions = {}) => {
+export const exportRecordsPlugin = (job, opts: PluginOptions = {}) => {
   return (listener: FlatfileListener) => {
-    listener.on(
-      'job:ready',
-      { job: 'workbook:downloadWorkbook' },
-      async (event) => {
-        await run(event, opts)
-      }
-    )
+    listener.on('job:ready', job, async (event) => {
+      await exportRecords(event, opts)
+    })
   }
 }

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -14,10 +14,15 @@ import * as XLSX from 'xlsx'
 /**
  * Plugin config options.
  *
+ * @property {string[]} excludedSheets - list of sheet names to exclude from the exported data.
+ * @property {Flatfile.Filter} recordFilter - filter to apply to the records before exporting.
  * @property {boolean} includeRecordIds - include record ids in the exported data.
  * @property {boolean} debug - show helpul messages useful for debugging (use intended for development).
  */
 export interface PluginOptions {
+  readonly excludedSheets?: string[]
+  readonly excludeFields?: string[]
+  readonly recordFilter?: Flatfile.Filter
   readonly includeRecordIds?: boolean
   readonly debug?: boolean
 }
@@ -28,14 +33,16 @@ export interface PluginOptions {
  * @param event - Flatfile event
  * @param options - plugin config options
  */
-export const run = async (
+export const exportRecords = async (
   event: FlatfileEvent,
   options: PluginOptions
 ): Promise<void> => {
   const { environmentId, jobId, spaceId, workbookId } = event.context
 
   try {
+    const { data: workbook } = await api.workbooks.get(workbookId)
     const { data: sheets } = await api.sheets.list({ workbookId })
+    const fileName = sanitizeFileName(workbook.name)
 
     if (options.debug) {
       const meta = R.pipe(
@@ -51,7 +58,7 @@ export const run = async (
       )
     }
 
-    const workbook = XLSX.utils.book_new()
+    const xlsxWorkbook = XLSX.utils.book_new()
 
     try {
       await api.jobs.ack(jobId, {
@@ -60,68 +67,91 @@ export const run = async (
       })
 
       for (const [sheetIndex, sheet] of sheets.entries()) {
+        if (options.excludedSheets?.includes(sheet.config.slug)) {
+          if (options.debug) {
+            logInfo(
+              '@flatfile/plugin-export-workbook',
+              `Skipping sheet: ${sheet.name}`
+            )
+          }
+          continue
+        }
         try {
-          const results = await processRecords<Record<string, any>[]>(
+          let results = await processRecords<Record<string, any>[]>(
             sheet.id,
             (records): Record<string, any>[] => {
               return R.pipe(
                 records,
-                R.map(({ id, values: row }) => {
-                  const rowValue = R.pipe(
-                    Object.keys(row),
-                    R.reduce((acc, colName) => {
-                      const formatCell = (cellValue: Flatfile.CellValue) => {
-                        const { value, messages } = cellValue
-                        const cell: XLSX.CellObject = {
-                          t: 's',
-                          v: value,
-                          c: [],
+                R.map(
+                  ({
+                    id: recordId,
+                    values: row,
+                  }: {
+                    id: string
+                    values: any
+                  }) => {
+                    const rowValue = R.pipe(
+                      Object.keys(row),
+                      R.reduce((acc, colName) => {
+                        if (options.excludeFields?.includes(colName)) {
+                          return acc
                         }
-                        if (R.length(messages) > 0) {
-                          cell.c = messages.map((m) => ({
-                            a: 'Flatfile',
-                            t: `[${m.type.toUpperCase()}]: ${m.message}`,
-                            T: true,
-                          }))
-                          cell.c.hidden = true
+                        const formatCell = (cellValue: Flatfile.CellValue) => {
+                          const { value, messages } = cellValue
+                          const cell: XLSX.CellObject = {
+                            t: 's',
+                            v: value,
+                            c: [],
+                          }
+                          if (R.length(messages) > 0) {
+                            cell.c = messages.map((m) => ({
+                              a: 'Flatfile',
+                              t: `[${m.type.toUpperCase()}]: ${m.message}`,
+                              T: true,
+                            }))
+                            cell.c.hidden = true
+                          }
+
+                          return cell
                         }
 
-                        return cell
-                      }
-
-                      return {
-                        ...acc,
-                        [colName]: formatCell(row[colName]),
-                      }
-                    }, {})
-                  )
-                  return options?.includeRecordIds
-                    ? {
-                        id,
-                        ...rowValue,
-                      }
-                    : rowValue
-                })
+                        return {
+                          ...acc,
+                          [colName]: formatCell(row[colName]),
+                        }
+                      }, {})
+                    )
+                    return options?.includeRecordIds
+                      ? {
+                          recordId,
+                          ...rowValue,
+                        }
+                      : rowValue
+                  }
+                )
               )
+            },
+            {
+              filter: options.recordFilter,
             }
           )
-          if (!results) {
-            if (options.debug) {
-              logWarn(
-                '@flatfile/plugin-export-workbook',
-                `No records found for sheet with id: ${sheet.id}. Skipping.`
-              )
+          if (!results || results.every((group) => group.length === 0)) {
+            const emptyCell: XLSX.CellObject = {
+              t: 's',
+              v: '',
+              c: [],
             }
-            continue
+            results = [
+              sheet.config.fields.map((field) => ({ [field.key]: emptyCell })),
+            ]
           }
           const rows = results.flat()
 
           const worksheet = XLSX.utils.json_to_sheet(rows)
 
           XLSX.utils.book_append_sheet(
-            workbook,
+            xlsxWorkbook,
             worksheet,
-            // Limit sheet name to 31 characters
             sanitizeExcelSheetName(sheet.name, sheetIndex)
           )
         } catch (_getRecordsError: unknown) {
@@ -155,11 +185,30 @@ export const run = async (
     }
 
     // Lambdas only allow writing to /tmp directory
-    const fileName = path.join('/tmp', `Workbook-${currentEpoch()}.xlsx`)
+    const timestamp = new Date().toISOString()
+    const filePath = path.join('/tmp', `${fileName}-${timestamp}.xlsx`)
+
+    if (xlsxWorkbook.SheetNames.length === 0) {
+      if (options.debug) {
+        logError(
+          '@flatfile/plugin-export-workbook',
+          'No data to write to Excel file'
+        )
+      }
+
+      await api.jobs.fail(jobId, {
+        outcome: {
+          message:
+            'Job failed because there were no data to write to Excel file.',
+        },
+      })
+
+      return
+    }
 
     try {
       XLSX.set_fs(fs)
-      XLSX.writeFileXLSX(workbook, fileName) //, { cellStyles: true })
+      XLSX.writeFile(xlsxWorkbook, filePath)
 
       if (options.debug) {
         logInfo('@flatfile/plugin-export-workbook', 'File written to disk')
@@ -181,7 +230,7 @@ export const run = async (
     }
 
     try {
-      const reader = fs.createReadStream(fileName)
+      const reader = fs.createReadStream(filePath)
 
       await api.files.upload(reader, {
         spaceId,
@@ -191,7 +240,7 @@ export const run = async (
 
       reader.close()
 
-      await fs.promises.unlink(fileName)
+      await fs.promises.unlink(filePath)
 
       if (options.debug) {
         logInfo(
@@ -257,6 +306,19 @@ export const run = async (
   }
 }
 
+function sanitizeFileName(fileName: string): string {
+  // List of invalid characters that are commonly not allowed in file names
+  const invalidChars = /[\/\?%\*:|"<>]/g
+
+  // Remove invalid characters
+  let cleanFileName = fileName.replace(invalidChars, '_')
+
+  // Remove emojis and other non-ASCII characters
+  cleanFileName = cleanFileName.replace(/[^\x00-\x7F]/g, '')
+
+  return cleanFileName
+}
+
 function sanitizeExcelSheetName(name: string, index: number): string {
   // Regular expression to match unsupported Excel characters
   const invalidChars = /[\\\/\?\*\[\]:<>|"]/g
@@ -272,7 +334,7 @@ function sanitizeExcelSheetName(name: string, index: number): string {
     sanitized = sanitized.substring(0, 31)
   }
 
-  // If the sheet name is empty, use a default name
+  // If the sheet name is empty, use a default name based on index (i.e. "Sheet1")
   if (sanitized.length === 0) {
     sanitized = `Sheet${index + 1}` //index is 0-based, default sheet names should be 1-based
   }
@@ -300,8 +362,4 @@ const genCyclicPattern = (length: number = 104): Array<string> => {
   }
 
   return alphaPattern
-}
-
-const currentEpoch = (): string => {
-  return `${Math.floor(Date.now() / 1000)}`
 }


### PR DESCRIPTION
Closes https://github.com/FlatFilers/support-triage/issues/1053

## Tell code reviewer what to test:
Create a sheet with a name containing a special character, then download the workbook. It should strip the special character from the name.

## Summary:

Excel does not support certain characters in sheet names due to its file format and system compatibility requirements. Here are the characters that are not allowed in Excel sheet names:
* Colon `:`
* Forward slash `/`
* Backslash `\`
* Question mark `?`
* Asterisk `*`
* Square brackets `[ ]`
* Greater than `>`
* Less than `<`
* Vertical bar `|`
* Double quotation mark `""`

Additionally, sheet names cannot begin or end with an apostrophe `'` and they must be under 31 characters in length.

This release strips invalid characters from the sheet name.