### PR TITLE
feat: cast to string

### DIFF
--- a/.changeset/large-pigs-sleep.md
+++ b/.changeset/large-pigs-sleep.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-autocast': patch
+---
+
+This release adds string casting to the autocast plugin.

--- a/plugins/autocast/src/autocast.plugin.spec.ts
+++ b/plugins/autocast/src/autocast.plugin.spec.ts
@@ -4,10 +4,23 @@ import {
   castBoolean,
   castDate,
   castNumber,
+  castString,
 } from './autocast.plugin'
 
 describe('autocast plugin', () => {
   describe('cast functions', () => {
+    describe('should return the string', () => {
+      expect(castString('foo')).toBe('foo')
+    })
+    describe('should return a numeric value to string', () => {
+      expect(castString(1)).toBe('1')
+      expect(castString(1.1)).toBe('1.1')
+      expect(castString(-1)).toBe('-1')
+    })
+    describe('should return a boolean string', () => {
+      expect(castString(true)).toBe('true')
+      expect(castString(false)).toBe('false')
+    })
     describe.each(['1', 1])('should return a number', (num) => {
       expect(castNumber(num)).toBe(1)
     })

--- a/plugins/autocast/src/autocast.plugin.ts
+++ b/plugins/autocast/src/autocast.plugin.ts
@@ -64,9 +64,21 @@ export function autocast(
 const CASTING_FUNCTIONS: {
   [key: string]: (value: TPrimitive) => TPrimitive
 } = {
+  string: castString,
   number: castNumber,
   boolean: castBoolean,
   date: castDate,
+}
+
+export function castString(value: TPrimitive): TPrimitive {
+  if (typeof value === 'string') {
+    return value
+  } else if (typeof value === 'number') {
+    return value.toString()
+  } else if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
+  throw new Error(`Failed to cast '${value}' to 'string'`)
 }
 
 export function castNumber(value: TPrimitive): TPrimitive {


### PR DESCRIPTION
Closes https://github.com/FlatFilers/support-triage/issues/1060

## Tell code reviewer what to test:
Create a sheet with a field of type `string` and insert an integer value. The autocast plugin will cast it to a string.

## Tell Chat GPT how to summarize this pull request:
Since it is possible to insert a number or boolean into a field of type `string`, this release adds cast-to-string functionality to the autocast plugin.