### PR TITLE
feat: processRecords update

### DIFF
--- a/.changeset/fresh-humans-prove.md
+++ b/.changeset/fresh-humans-prove.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/util-common': patch
+---
+
+The release exposes additional record request options such as "filter" and passes the current pageNumber to the cb function. Additionally the cb will be called when no records are found for any wrap-up the cb needs to make.

--- a/.changeset/fresh-humans-prove.md
+++ b/.changeset/fresh-humans-prove.md
@@ -1,5 +1,9 @@
 ---
-'@flatfile/util-common': patch
+'@flatfile/util-common': major
+'@flatfile/util-response-rejection': patch
 ---
 
-The release exposes additional record request options such as "filter" and passes the current pageNumber to the cb function. Additionally the cb will be called when no records are found for any wrap-up the cb needs to make.
+@flatfile/util-common: This release provides additional record request options such as "filter" and passes the current pageNumber to the cb function. Additionally the cb will be called when no records are found for any wrap-up the cb needs to make.
+
+@flatfile/util-response-rejection: Since @flatfile/util-common now calls the cb when no records are found, this release updates @flatfile/util-response-rejection to check for records before processing.
+```

--- a/plugins/webhook-egress/src/webhook.egress.spec.ts
+++ b/plugins/webhook-egress/src/webhook.egress.spec.ts
@@ -92,7 +92,15 @@ describe('webhookEgress() e2e', () => {
     )
 
     const logErrorSpy = jest.spyOn(global.console, 'error')
-
+    logErrorSpy.mockImplementation((message) => {
+      if (
+        message.includes(
+          'Data was not successfully submitted to the provided webhook. Status: 400 Bad Request'
+        )
+      ) {
+        console.error(message)
+      }
+    })
     listener.use(webhookEgress('workbook:egressTestFailure', 'example.com'))
 
     const { data: failedJob } = await api.jobs.create({

--- a/utils/common/src/process.records.spec.ts
+++ b/utils/common/src/process.records.spec.ts
@@ -1,0 +1,126 @@
+import api from '@flatfile/api'
+import { getEnvironmentId, setupSpace } from '@flatfile/utils-testing'
+import { processRecords } from './process.records'
+
+describe('processRecords', () => {
+  let spaceId: string
+  let emptySheetId: string
+  let populatedSheetId: string
+
+  beforeAll(async () => {
+    const space = await setupSpace()
+    spaceId = space.id
+
+    const fields = ['name', 'email', 'notes']
+    const { data: workbook } = await api.workbooks.create({
+      name: 'ci-wb-' + Date.now(),
+      spaceId: spaceId,
+      environmentId: getEnvironmentId(),
+      sheets: [
+        {
+          name: 'Empty Records Sheet',
+          slug: 'empty',
+          fields: fields.map((field) =>
+            typeof field === 'string' ? { key: field, type: 'string' } : field
+          ),
+        },
+        {
+          name: 'Populated Records Sheet',
+          slug: 'populated',
+          fields: fields.map((field) =>
+            typeof field === 'string' ? { key: field, type: 'string' } : field
+          ),
+        },
+      ],
+    })
+
+    const findSheetId = (slug: string) => {
+      return workbook.sheets.find((sheet) => sheet.config.slug === slug).id
+    }
+
+    emptySheetId = findSheetId('empty')
+    populatedSheetId = findSheetId('populated')
+
+    const generateRecords = (length) => {
+      const records = []
+      for (let i = 0; i < length; i++) {
+        records.push({
+          name: { value: 'John Doe' },
+          email: { value: 'john@doe.com' },
+          notes: { value: 'Some notes' },
+        })
+      }
+      return records
+    }
+
+    await api.records.insert(populatedSheetId, generateRecords(3000))
+  })
+
+  afterAll(async () => {
+    await api.spaces.delete(spaceId)
+  })
+
+  it('should call callback function', async () => {
+    const callback = jest.fn()
+
+    await processRecords(emptySheetId, callback)
+    expect(callback).toHaveBeenCalled()
+
+    callback.mockClear()
+
+    await processRecords(populatedSheetId, callback)
+    expect(callback).toHaveBeenCalled()
+  })
+
+  it('should return results', async () => {
+    const callback = jest.fn((records) => records.length)
+
+    const emptyResults = await processRecords(emptySheetId, callback)
+    expect(emptyResults).toEqual([0])
+
+    const populatedResults = await processRecords(populatedSheetId, callback)
+    expect(populatedResults).toEqual([3000, 0])
+  })
+
+  it('should filter records by "valid" status', async () => {
+    const callback = jest.fn((records) => records.length)
+
+    const emptyResults = await processRecords(emptySheetId, callback, {
+      filter: 'valid',
+    })
+    expect(emptyResults).toEqual([0])
+
+    const populatedResults = await processRecords(populatedSheetId, callback, {
+      filter: 'valid',
+    })
+    expect(populatedResults).toEqual([3000, 0])
+  })
+
+  it('should filter records by "error" status', async () => {
+    const callback = jest.fn((records) => records.length)
+
+    const emptyResults = await processRecords(emptySheetId, callback, {
+      filter: 'error',
+    })
+    expect(emptyResults).toEqual([0])
+
+    const populatedResults = await processRecords(populatedSheetId, callback, {
+      filter: 'error',
+    })
+    expect(populatedResults).toEqual([0])
+  })
+
+  it('should fetch records with custom page size', async () => {
+    const callback = jest.fn((records) => records.length)
+
+    const emptyResults = await processRecords(emptySheetId, callback, {
+      pageSize: 500,
+    })
+    expect(emptyResults).toEqual([0])
+
+    const populatedResults = await processRecords(populatedSheetId, callback, {
+      pageSize: 500,
+    })
+    expect(populatedResults).toEqual([500, 500, 500, 500, 500, 500, 0])
+  })
+})

--- a/utils/common/src/process.records.ts
+++ b/utils/common/src/process.records.ts
@@ -3,9 +3,10 @@ import api, { Flatfile } from '@flatfile/api'
 export async function processRecords<R>(
   sheetId: string,
   callback: (
-    records: Flatfile.RecordsWithLinks
+    records: Flatfile.RecordsWithLinks,
+    pageNumber?: number
   ) => R | void | Promise<R | void>,
-  recordGetOptions?: Omit<Flatfile.records.GetRecordsRequest, 'pageNumber'>
+  getRecordsRequest?: Omit<Flatfile.records.GetRecordsRequest, 'pageNumber'>
 ): Promise<R[] | void> {
   let pageNumber = 1
   const results: R[] = []
@@ -14,17 +15,17 @@ export async function processRecords<R>(
     const {
       data: { records },
     } = await api.records.get(sheetId, {
-      ...recordGetOptions,
+      ...getRecordsRequest,
       pageNumber: pageNumber++,
     })
 
-    if (records.length === 0) {
-      break
-    }
-
-    const result = await callback(records)
+    const result = await callback(records, pageNumber - 1)
     if (result !== undefined && result !== null) {
       results.push(result as R)
+    }
+
+    if (records.length === 0) {
+      break
     }
   }
 

--- a/utils/common/src/process.records.ts
+++ b/utils/common/src/process.records.ts
@@ -6,7 +6,7 @@ export async function processRecords<R>(
     records: Flatfile.RecordsWithLinks,
     pageNumber?: number
   ) => R | void | Promise<R | void>,
-  getRecordsRequest?: Omit<Flatfile.records.GetRecordsRequest, 'pageNumber'>
+  getRecordsRequest?: GetRecordsRequest
 ): Promise<R[] | void> {
   let pageNumber = 1
   const results: R[] = []
@@ -31,3 +31,8 @@ export async function processRecords<R>(
 
   return results.length ? results : undefined
 }
+
+export type GetRecordsRequest = Omit<
+  Flatfile.records.GetRecordsRequest,
+  'pageNumber'
+>


### PR DESCRIPTION
@flatfile/util-common: This release provides additional record request options such as "filter" and passes the current pageNumber to the cb function. Additionally the cb will be called when no records are found for any wrap-up the cb needs to make.

@flatfile/util-response-rejection: Since @flatfile/util-common now calls the cb when no records are found, this release updates @flatfile/util-response-rejection to check for records before processing.