### PR TITLE
feat: disable test & lint on changeset branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches:
       - main
-      - '!changeset-release/main'
+    branches-ignore:
+      - changeset-release/main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    branches-ignore:
-      - changeset-release/main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -14,6 +12,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
+      - name: Check source branch
+        run: |
+          if [[ "${{ github.head_ref }}" == "changeset-release/main" ]]; then
+            echo "PR is from changeset-release/main, stopping workflow."
+            exit 0
+          fi
+
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     branches:
       - main
-    branches-ignore:
-      - changeset-release/main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -15,6 +13,13 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
+      - name: Check source branch
+        run: |
+          if [[ "${{ github.head_ref }}" == "changeset-release/main" ]]; then
+            echo "PR is from changeset-release/main, stopping workflow."
+            exit 0
+          fi
+
       - name: Check out code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     branches:
       - main
-      - '!changeset-release/main'
+    branches-ignore:
+      - changeset-release/main
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
This PR disables the `test` and `lint` workflows on the `changeset-release/main` branch.