### PR TITLE
fix: excel extractor header detection bug

### DIFF
--- a/.changeset/rich-carrots-hope.md
+++ b/.changeset/rich-carrots-hope.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-xlsx-extractor': patch
+---
+
+This release fixes a bug in @flatfile/plugin-excel-extractor when using the explicitHeaders header detection algorithm.

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -99,7 +99,7 @@ async function convertSheet(
   const headerizer = Headerizer.create(headerDetectionOptions)
   const headerStream = Readable.from(extractValues(rows))
   const { header, skip } = await headerizer.getHeaders(headerStream)
-  const headerKey = skip - 1
+  const headerKey = skip > 0 ? skip - 1 : 0
   const columnKeys = Object.keys(rows[headerKey]).filter((key) =>
     Boolean(rows[headerKey][key])
   )

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -99,7 +99,7 @@ async function convertSheet(
   const headerizer = Headerizer.create(headerDetectionOptions)
   const headerStream = Readable.from(extractValues(rows))
   const { header, skip } = await headerizer.getHeaders(headerStream)
-  const headerKey = skip > 0 ? skip - 1 : 0
+  const headerKey = Math.max(0, skip - 1)
   const columnKeys = Object.keys(rows[headerKey]).filter((key) =>
     Boolean(rows[headerKey][key])
   )


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
This release fixes a bug in @flatfile/plugin-excel-extractor when using the explicitHeaders header detection algorithm.

## Tell code reviewer how and what to test:
Extraction should not error when using the `explicitHeaders` algorithm
```
listener.use(
  ExcelExtractor({
    headerDetectionOptions: {
      algorithm: 'explicitHeaders',
      headers: ['fiRsT NamE', 'LaSt nAme', 'emAil'],
    },
  })
)
```