### PR TITLE
feat: add readme content and package keywords to extractors plugins

### DIFF
--- a/.changeset/healthy-turkeys-flow.md
+++ b/.changeset/healthy-turkeys-flow.md
@@ -1,0 +1,10 @@
+---
+'@flatfile/plugin-delimiter-extractor': patch
+'@flatfile/plugin-json-extractor': patch
+'@flatfile/plugin-xlsx-extractor': patch
+'@flatfile/plugin-pdf-extractor': patch
+'@flatfile/plugin-xml-extractor': patch
+'@flatfile/plugin-zip-extractor': patch
+---
+
+Add readme content and package keywords

--- a/plugins/delimiter-extractor/README.md
+++ b/plugins/delimiter-extractor/README.md
@@ -1,9 +1,114 @@
-# @flatfile/plugin-delimiter-extractor
+<!-- START_INFOCARD -->
 
-This plugin parses a delimited file and extracts it into Flatfile.
+The `@flatfile/plugin-delimiter-extractor` package is a plugin for parsing delimited files and extracting them into Flatfile. It utilizes various libraries to parse files and retrieve the structured data efficiently.
 
-`npm i @flatfile/plugin-delimiter-extractor`
+**Event Type:**
+`listener.on('file:created')`
 
-## Get Started
+**Supported delimiters:**
+`;`, `:`, `~`, `^`, `#`
 
-Follow [this guide](https://flatfile.com/docs/plugins/extractors/delimiter-extractor) to learn how to use the plugin.
+**Note:** `\t`, `|`, and `,` are handled natively in the platform.
+
+<!-- END_INFOCARD -->
+
+> When embedding Flatfile, this plugin should be deployed in a server-side listener. [Learn more](/deocs/orchestration/listeners#listener-types)
+
+
+## Parameters
+
+#### `fileExt` - `string` - (required)
+The `fileExt` parameter is used to specify the file name or extension to
+listen for.
+
+
+#### `options.delimiter` - `string` - (required)
+The `delimiter` parameter is used to specify the delimiter used in the file.
+
+
+#### `options.dynamicTyping` - `boolean` - `default: "false"`
+If `true`, numeric and boolean data will be converted to their type instead of
+remaining strings. Numeric data must conform to the definition of a decimal
+literal. Numerical values greater than 2^53 or less than -2^53 will not be
+converted to numbers to preserve precision. European-formatted numbers must
+have commas and dots swapped.
+
+
+#### `options.skipEmptyLines` - `boolean | 'greedy'`
+If `true`, lines that are completely empty (those which evaluate to an empty
+string) will be skipped. If set to `greedy`, lines that don't have any content
+(those which have only whitespace after parsing) will also be skipped.
+
+
+#### `options.transform` - `function`
+A function to apply on each value. The function receives the value as an
+argument The return value of the function will replace the value it received.
+The transform function is applied before `dynamicTyping`.
+
+
+#### `options.chunkSize` - `default: 10_000` - `number` - (optional)
+The `chunkSize` parameter allows you to specify the quantity of records to in
+each chunk.
+
+
+#### `options.parallel` - `default: 1` - `number` - (optional)
+The `parallel` parameter allows you to specify the number of chunks to process
+in parallel.
+
+
+
+## API Calls
+
+- `api.files.download`
+- `api.files.get`
+- `api.files.update`
+- `api.jobs.ack`
+- `api.jobs.complete`
+- `api.jobs.create`
+- `api.jobs.fail`
+- `api.jobs.update`
+- `api.records.insert`
+- `api.workbooks.create`
+
+
+
+## Usage
+
+Listen for an delimited file to be uploaded to Flatfile. The platform will then extract the file automatically. Once complete, the file will be ready for import in the Files area.
+
+```bash install
+npm i @flatfile/plugin-delimiter-extractor
+```
+
+```js import
+import { DelimiterExtractor } from "@flatfile/plugin-delimiter-extractor";
+```
+
+```js listener.js
+listener.use(DelimiterExtractor(".txt", { delimiter: ":" }));
+```
+
+
+### Full Example
+
+In this example, the DelimiterExtractor is initialized for extracting TXT files with optional options, and then registered as middleware with the Flatfile listener. When a TXT file is uploaded, the plugin will extract the structured data and process it using the extractor's parser.
+
+```javascript
+import { DelimiterExtractor } from "@flatfile/plugin-delimiter-extractor";
+
+// Define optional options for the extractor (e.g., { dynamicTyping: true })
+const options = {
+  delimiter: ":",
+  dynamicTyping: true,
+  skipEmptyLines: true,
+  transform: (value) => value.toUpperCase(),
+};
+
+// Initialize the TXT extractor
+const delimiterExtractor = DelimiterExtractor(".txt", options);
+
+// Register the extractor as a middleware for the Flatfile listener
+listener.use(delimiterExtractor);
+
+// When a TXT file is uploaded, the data will be extracted and processed using the extractor's parser.
+```

--- a/plugins/delimiter-extractor/package.json
+++ b/plugins/delimiter-extractor/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@flatfile/plugin-delimiter-extractor",
   "version": "0.9.1",
-  "description": "A plugin for parsing a delimited file and extracting it into Flatfile.",
+  "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/delimiter-extractor",
+  "description": "A plugin for parsing .delimiter files in Flatfile.",
   "registryMetadata": {
     "category": "extractors"
   },
@@ -18,7 +19,10 @@
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
     "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
-  "keywords": [],
+  "keywords": [
+    "flatfile-plugins",
+    "category-extractors"
+  ],
   "author": "Carl Brugger",
   "repository": {
     "type": "git",

--- a/plugins/json-extractor/README.md
+++ b/plugins/json-extractor/README.md
@@ -1,9 +1,78 @@
-# @flatfile/plugin-json-extractor
+<!-- START_INFOCARD -->
 
-This package parses a JSON file and extracts it into Flatfile.
+The `@flatfile/json-extractor` plugin parses a JSON file and extracts first-level nested objects as Sheets in Flatfile.
 
-`npm i @flatfile/plugin-json-extractor`
+**Event Type:** 
+`listener.on('file:created')`
 
-## Get Started
+**Supported file types:** 
+`.json`
 
-Follow [this guide](https://flatfile.com/docs/plugins/extractors/json-extractor) to learn how to use the plugin.
+<!-- END_INFOCARD -->
+
+> When embedding Flatfile, this plugin should be deployed in a server-side listener. [Learn more](/docs/orchestration/listeners#listener-types)
+
+
+
+## Parameters
+
+#### `options.chunkSize` - `default: "10_000"` - `number` - (optional)
+The `chunkSize` parameter allows you to specify the quantity of records to in each chunk.
+
+
+#### `options.parallel` - `default: "1"` - `number` - (optional)
+The `parallel` parameter allows you to specify the number of chunks to process in parallel.
+
+
+
+## API Calls
+
+- `api.files.download`
+- `api.files.get`
+- `api.files.update`
+- `api.jobs.ack`
+- `api.jobs.complete`
+- `api.jobs.create`
+- `api.jobs.fail`
+- `api.jobs.update`
+- `api.records.insert`
+- `api.workbooks.create`
+
+
+
+## Usage
+
+Listen for a JSON file to be uploaded to Flatfile. The platform will then extract the file automatically. Once complete, the file will be ready for import in the Files area.
+
+```bash Install
+npm i @flatfile/plugin-json-extractor
+```
+
+```js import
+import { JSONExtractor } from "@flatfile/plugin-json-extractor";
+```
+
+```js listener.js
+listener.use(JSONExtractor());
+```
+
+
+
+### Full Example
+
+In this example, the `JSONExtractor` is initialized, and then registered as middleware with the Flatfile listener. When a JSON file is uploaded, the plugin will extract the structured data and process it the extractor's parser.
+
+```javascript
+import { JSONExtractor } from "@flatfile/plugin-json-extractor";
+
+// Initialize the JSON extractor
+const jsonExtractor = JSONExtractor();
+
+// Register the extractor as a middleware for the Flatfile listener
+listener.use(jsonExtractor);
+
+// When a JSON file is uploaded, the data will be extracted and processed using the extractor's parser.
+```
+
+See a working example in our [flatfile-docs-kitchen-sink](https://github.com/FlatFilers/flatfile-docs-kitchen-sink/blob/main/typescript/extractors/index.ts) Github repo.
+

--- a/plugins/json-extractor/package.json
+++ b/plugins/json-extractor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@flatfile/plugin-json-extractor",
   "version": "0.7.2",
+  "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/json-extractor",
   "description": "A plugin for parsing json files in Flatfile.",
   "registryMetadata": {
     "category": "extractors"
@@ -38,7 +39,10 @@
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
     "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
-  "keywords": [],
+  "keywords": [
+    "flatfile-plugins",
+    "category-extractors"
+  ],
   "author": "Carl Brugger",
   "repository": {
     "type": "git",

--- a/plugins/pdf-extractor/README.md
+++ b/plugins/pdf-extractor/README.md
@@ -1,9 +1,62 @@
-# @flatfile/plugin-pdf-extractor
+<!-- START_INFOCARD -->
 
-This package parses a PDF file and extracts it into Flatfile.
+This plugin will parse a data table in a PDF file and extract it into Flatfile.
 
-`npm i @flatfile/plugin-pdf-extractor`
+**Event Type:**
+`listener.on('file:created')`
 
-## Get Started
+<!-- END_INFOCARD -->
 
-Follow [this guide](https://flatfile.com/docs/plugins/extractors/pdf-extractor) to learn how to use the plugin.
+
+> When embedding Flatfile, this plugin should be deployed in a server-side listener. [Learn more](/docs/orchestration/listeners#listener-types)
+
+
+
+## Parameters
+
+#### `opt.apiKey` - `string` - (required)
+The `apiKey` parameter specifies you `pdftables.com` API key.
+
+#### `opt.debug` - `boolean`
+The `debug` parameter lets you toggle on/off helpful debugging messages for
+development purposes.
+
+
+
+## API Calls
+
+- `api.files.upload`
+
+
+
+## Usage
+
+A subscription to `pdftables.com` is required for this plugin to work. Create an API key there and use it below.
+
+```bash install
+npm i @flatfile/plugin-pdf-extractor
+```
+
+```ts import
+import { pdfExtractorPlugin } from "@flatfile/plugin-pdf-extractor";
+```
+
+#### JavaScript 
+
+**listener.js**  
+
+```js listener.js
+export default function (listener) {
+  listener.use(pdfExtractorPlugin({ apiKey: "key" }));
+}
+```
+
+#### TypeScript
+
+**listener.ts**  
+
+```ts listener.ts
+export default function (listener: FlatfileListener) {
+  listener.use(pdfExtractorPlugin({ apiKey: "key" }));
+}
+```

--- a/plugins/pdf-extractor/package.json
+++ b/plugins/pdf-extractor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@flatfile/plugin-pdf-extractor",
   "version": "0.1.3",
+  "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/pdf-extractor",
   "description": "A plugin for parsing PDF files in Flatfile.",
   "registryMetadata": {
     "category": "extractors"
@@ -18,7 +19,10 @@
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
     "test": "jest --passWithNoTests"
   },
-  "keywords": [],
+  "keywords": [
+    "flatfile-plugins",
+    "category-extractors"
+  ],
   "author": "Flatfile, Inc.",
   "repository": {
     "type": "git",

--- a/plugins/xlsx-extractor/README.md
+++ b/plugins/xlsx-extractor/README.md
@@ -1,9 +1,198 @@
-# @flatfile/plugin-xlsx-extractor
+<!-- START_INFOCARD -->
 
-This package parses all Sheets in an XLSX file and extracts them into Flatfile.
+The `@flatfile/plugin-xlsx-extractor` plugin is designed to extract structured data from Excel files. It utilizes various libraries to parse Excel files and retrieve the structured data efficiently.
 
-`npm i @flatfile/plugin-xlsx-extractor`
+**Event Type:** 
+`listener.on('file:created')`
 
-## Get Started
+**Supported file types:** 
+`.xls`, `.xlsx`, `.xlsm`, `.xlsb`, `.xltx`, `.xltm`
 
-Follow [this guide](https://flatfile.com/docs/plugins/extractors/xlsx-extractor) to learn how to use the plugin.
+<!-- END_INFOCARD -->
+
+
+> When embedding Flatfile, this plugin should be deployed in a server-side listener. [Learn more](/docs/orchestration/listeners#listener-types)
+
+
+
+## Parameters
+
+#### `raw` - `boolean` 
+In Excel, you could have formatting on a text cell (i.e. date formatting). By
+default, Flatfile will just take the formatted text versus the raw values. Set
+this value to true to take the raw values and disregard how it's displayed in
+Excel.
+
+#### `rawNumbers` - `boolean`
+In Excel, you could have rounding or formatting on a number cell to only
+display say 2 decimal places. By default, Flatfile will just take the
+displayed decimal places versus the raw numbers. Set this value to true to
+take the raw numbers and disregard how it's displayed in Excel.
+
+
+#### `dateNF` - `string` - (optional)
+The `dateNF` parameter allows you to specify the date format for parsing
+dates. (i.e. `yyyy-mm-dd`)
+
+
+#### `chunkSize` - `default: "10_000"` - `number` - (optional)
+The `chunkSize` parameter allows you to specify the quantity of records to in
+each chunk.
+
+
+#### `parallel` - `default: "1"` - `number` - (optional)
+The `parallel` parameter allows you to specify the number of chunks to process
+in parallel.
+
+
+#### `headerDetectionOptions` - `Object` - (optional)
+The `headerDetectionOptions` parameter allows you to specify the options for
+detecting headers in the file. By default, the first 10 rows are scanned for
+the row with the most non-empty cells.
+
+
+#### `debug` - `default: "false"` - `boolean` - (optional)
+The `debug` parameter lets you toggle on/off helpful debugging messages for
+development purposes.
+
+
+
+## API Calls
+
+- `api.files.download`
+- `api.files.get`
+- `api.files.update`
+- `api.jobs.ack`
+- `api.jobs.complete`
+- `api.jobs.create`
+- `api.jobs.fail`
+- `api.jobs.update`
+- `api.records.insert`
+- `api.workbooks.create`
+
+
+
+## Usage
+
+Listen for an Excel file (all extensions supported) to be uploaded to Flatfile. The platform will then extract the file automatically. Once complete, the file will be ready for import in the Files area.
+
+```bash install
+npm i @flatfile/plugin-xlsx-extractor
+```
+
+```js import
+import { ExcelExtractor } from "@flatfile/plugin-xlsx-extractor";
+```
+
+**listener.js**
+
+```js listener.js
+listener.use(ExcelExtractor());
+```
+
+**Additional options**  
+
+```js additional options
+listener.use(ExcelExtractor({ raw: true, rawNumbers: true }));
+```
+
+
+### Header Detection
+
+Three detection options are provided for detecting headers in the file: `default`, `explicitHeaders`, and `specificRows`. By default, the first 10 rows are scanned for the row with the most non-empty cells. This row is then used as the header row.
+
+#### Default
+
+It looks at the first `rowsToSearch` rows and takes the row
+with the most non-empty cells as the header, preferring the earliest
+such row in the case of a tie.
+
+```js
+listener.use(ExcelExtractor());
+// or...
+listener.use(
+  ExcelExtractor({
+    headerDetectionOptions: {
+      algorithm: "default",
+      rowsToSearch: 30, // Default is 10
+    },
+  })
+);
+```
+
+#### Explicit Headers
+
+This implementation simply returns an explicit list of headers it was provided with.
+
+```js
+listener.use(
+  ExcelExtractor({
+    headerDetectionOptions: {
+      algorithm: "explicitHeaders",
+      headers: ["fiRsT NamE", "LaSt nAme", "emAil"],
+    },
+  })
+);
+```
+
+#### Specific Rows
+
+This implementation looks at specific rows and combines them into a single header. For example, if you knew that the header was in the third row, you could pass it `{ rowNumbers: [2] }`.
+
+```js
+listener.use(
+  ExcelExtractor({
+    headerDetectionOptions: {
+      algorithm: "specificRows",
+      rowNumbers: [2], // 0 based
+    },
+  })
+);
+```
+
+#### Data Row & Sub Header Detection
+
+This implementation attempts to detect the first data row and select the previous
+row as the header. If the data row cannot be detected due to all the sample
+rows being full and not castable to a number or boolean type, it also will attempt
+to detect a sub header row by checking following rows after a header is detected
+for significant fuzzy matching. If over half of the fields in a possible sub header
+row fuzzy match with the originally detected header row, the sub header row becomes
+the new header.
+
+```js
+listener.use(
+  ExcelExtractor({
+    headerDetectionOptions: {
+      algorithm: "dataRowAndSubHeaderDetection",
+      rowsToSearch: 30, // Default is 10
+    },
+  })
+);
+```
+
+### Full Example
+
+In this example, the `ExcelExtractor` is initialized with optional options, and then registered as middleware with the Flatfile listener. When an Excel file is uploaded, the plugin will extract the structured data and process it using the extractor's parser.
+
+**listener.js**
+
+```js listener.js
+import { ExcelExtractor } from "@flatfile/plugin-xlsx-extractor";
+
+export default async function (listener) {
+  // Define optional options for the extractor
+  const options = {
+    raw: true,
+    rawNumbers: true,
+  };
+
+  // Initialize the Excel extractor
+  const excelExtractor = ExcelExtractor(options);
+
+  // Register the extractor as a middleware for the Flatfile listener
+  listener.use(excelExtractor);
+
+  // When an Excel file is uploaded, the data will be extracted and processed using the extractor's parser.
+}
+```

--- a/plugins/xlsx-extractor/package.json
+++ b/plugins/xlsx-extractor/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@flatfile/plugin-xlsx-extractor",
   "version": "1.11.5",
-  "description": "A plugin for parsing xlsx files in Flatfile.",
+  "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/xlsx-extractor",
+  "description": "A plugin for parsing Excel files in Flatfile.",
   "registryMetadata": {
     "category": "extractors"
   },
@@ -18,7 +19,10 @@
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
     "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
-  "keywords": [],
+  "keywords": [
+    "flatfile-plugins",
+    "category-extractors"
+  ],
   "author": "David Boskovic",
   "repository": {
     "type": "git",

--- a/plugins/xml-extractor/README.md
+++ b/plugins/xml-extractor/README.md
@@ -1,46 +1,40 @@
-# @flatfile/plugin-xml-extractor
+<!-- START_INFOCARD -->
 
-This plugin lets you easily extract data from XML files.
+The `@flatfile/xml-extractor` plugin is designed to extract structured data from
+XML files. It utilizes various libraries to parse XML files and retrieve the
+structured data efficiently.
+
+**Event Type:**
+`listener.on('file:created')`
+
+**Supported file types:**
+`.xml`
+
+<!-- END_INFOCARD -->
 
 
-## Get Started
+> When embedding Flatfile, this plugin should be deployed in a server-side listener. [Learn more](/docs/orchestration/listeners#listener-types)
 
-Follow [this guide](https://flatfile.com/docs/plugins/extractors/xml-extractor) to learn how to use the plugin.
 
-`listener.js`
+## Parameters
 
-```js
-import { XMLExtractor } from '@flatfile/plugin-xml-extractor'
-
-export default (listener) => {
-  listener.use(XMLExtractor())
-}
-```
-
-```js
-import { XMLExtractor } from '@flatfile/plugin-xml-extractor'
-
-export default (listener) => {
-  listener.use(
-    XMLExtractor({
-      separator: '/',
-      attributePrefix: '#',
-      transform: (row: Record<string, any>) => {
-      },
-    })
-  )
-}
-```
-
-## Configuration
-
-### `separator: string` (default `/`)
-
+#### `separator` - `string` - `default="/" ` - (optional)
 The separator to use when joining or flattening nested attributes.
 
-#### Example with default `/` separator
 
-```xml
+#### `options.chunkSize` - `default="10_000"` - `number` - (optional)
+The `chunkSize` parameter allows you to specify the quantity of records to in
+each chunk.
+
+
+#### `options.parallel` - `default="1"` - `number` - (optional)
+The `parallel` parameter allows you to specify the number of chunks to process
+in parallel.
+
+
+**Before:**  
+
+```xml before
 <?xml version="1.0" encoding="utf-8" ?>
 <root>
     <person>
@@ -54,7 +48,9 @@ The separator to use when joining or flattening nested attributes.
 </root>
 ```
 
-```json
+**After:**  
+
+```json after
 [
   {
     "name": "John",
@@ -65,13 +61,13 @@ The separator to use when joining or flattening nested attributes.
 ]
 ```
 
-## `attributePrefix: string` (default `#`)
 
-The prefix to use when flattening attributes of XML tags.
+#### `attributePrefix` - `string` - `default: "#"` - (optional)
+The prefix to use when flattening attributes of XML tags.  
 
-#### Example with default `#` prefix
+**Before:** 
 
-```xml
+```xml before
 <?xml version="1.0" encoding="utf-8" ?>
 <root>
     <person>
@@ -82,7 +78,9 @@ The prefix to use when flattening attributes of XML tags.
 </root>
 ```
 
-```json
+**After:**  
+
+```json after
 [
   {
     "name": "John",
@@ -93,14 +91,15 @@ The prefix to use when flattening attributes of XML tags.
 ]
 ```
 
-## `transform: (row) => Record<string, any>`
 
-A function that takes a row and returns a transformed row. This is useful for adjusting the data before it is loaded
-into Flatfile.
+#### `transform` - `(row) => Record<string, any>` - (optional)
+A function that takes a row and returns a transformed row. This is useful for
+adjusting the data before it is loaded into Flatfile.
 
-#### Example with transform
 
-```xml
+**Before:** 
+
+```xml before
 <?xml version="1.0" encoding="utf-8" ?>
 <root>
     <person>
@@ -114,11 +113,14 @@ into Flatfile.
         <country code="CA">Canada</country>
 
     </person>
+
 </root>
 ```
 
-```js
-import { XMLExtractor } from '@flatfile/plugin-xml-extractor'
+**listener.js** 
+
+```js listener.js
+import { XMLExtractor } from "@flatfile/plugin-xml-extractor";
 
 export default (listener) => {
   listener.use(
@@ -127,14 +129,16 @@ export default (listener) => {
         return {
           ...row,
           age: parseInt(row.age),
-        }
+        };
       },
     })
-  )
-}
+  );
+};
 ```
 
-```json
+**After:**  
+
+```json after
 [
   {
     "name": "John",
@@ -149,4 +153,38 @@ export default (listener) => {
     "country#code": "CA"
   }
 ]
+```
+
+
+## Usage
+
+Listen for an XML file to be uploaded to Flatfile. The platform will then extract the file automatically. Once complete, the file will be ready for import in the Files area.
+
+```bash install
+npm i @flatfile/plugin-xml-extractor
+```
+
+```js import
+import { XMLExtractor } from "@flatfile/plugin-xml-extractor";
+```
+
+**listener.js** 
+
+```js listener.js
+listener.use(XMLExtractor());
+```
+
+
+### Additional Options
+
+The extractor can accept additional properties. Props will be passed along to the Sheet.js parsing engine.
+
+```js
+listener.use(
+  XMLExtractor({
+    separator: "/",
+    attributePrefix: "#",
+    transform: (row: Record<string, any>) => {},
+  })
+);
 ```

--- a/plugins/xml-extractor/package.json
+++ b/plugins/xml-extractor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flatfile/plugin-xml-extractor",
   "version": "0.5.14",
-  "description": "A plugin for extracting data from XML files.",
+  "description": "A plugin for parsing .xml files in Flatfile.",
   "registryMetadata": {
     "category": "extractors"
   },
@@ -18,7 +18,10 @@
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
     "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
-  "keywords": [],
+  "keywords": [
+    "flatfile-plugins",
+    "category-extractors"
+  ],
   "author": "David Boskovic",
   "repository": {
     "type": "git",

--- a/plugins/zip-extractor/README.md
+++ b/plugins/zip-extractor/README.md
@@ -1,9 +1,70 @@
-# @flatfile/plugin-zip-extractor
+<!-- START_INFOCARD -->
 
-This package decompresses a zip file and uploads the decompressed files into Flatfile.
+The `@flatfile/plugin-zip-extractor` plugin decompresses ZIP files and uploads their contents to Flatfile for further processing by other extractors.
 
-`npm i @flatfile/plugin-zip-extractor`
+**Event Type:** 
+`listener.on('file:created')`
 
-## Get Started
+**Supported file types:** 
+`.zip`
 
-Follow [this guide](https://flatfile.com/docs/plugins/extractors/zip-extractor) to learn how to use the plugin.
+<!-- END_INFOCARD -->
+
+
+> When embedding Flatfile, this plugin should be deployed in a server-side listener. [Learn more](/docs/orchestration/listeners#listener-types)
+
+
+## Parameters
+
+#### `options.debug` - `default: false` - `boolean` - (optional)
+The `debug` parameter lets you toggle on/off helpful debugging messages for
+development purposes.
+
+
+
+## API Calls
+
+- `api.files.download`
+- `api.files.get`
+- `api.files.update`
+- `api.jobs.ack`
+- `api.jobs.complete`
+- `api.jobs.create`
+- `api.jobs.fail`
+- `api.jobs.update`
+
+
+
+## Usage
+
+Listen for a ZIP file to be uploaded to Flatfile. The file will be downloaded, unzipped, and the contents uploaded back to Flatfile. Once complete, the file will be ready for import in the Files area. This plugin is designed to be used in conjuction with other extractors, such as the [Excel Extractor](../extractors/xlsx-extractor), to extract and process the contents of the files contained in the ZIP file. Files with names beginning with `.` will be ignored as these are typically system files (i.e. `.DS_store`).
+
+```bash install
+npm i @flatfile/plugin-zip-extractor
+```
+
+```js import
+import { ZipExtractor } from "@flatfile/plugin-zip-extractor";
+```
+
+**listener.js**  
+
+```js listener.js
+listener.use(ZipExtractor());
+```
+
+### Full Example
+
+In this example, the `ZipExtractor` is initialized, and then registered as middleware with the Flatfile listener. When a JSON file is uploaded, the plugin will extract the contents of the ZIP file and upload the files to FlatFile.
+
+```javascript
+import { ZipExtractor } from "@flatfile/plugin-zip-extractor";
+
+// Initialize the ZIP extractor
+const zipExtractor = ZipExtractor();
+
+// Register the extractor as a middleware for the Flatfile listener
+listener.use(zipExtractor);
+
+// When a ZIP file is uploaded, the files will be extracted and uploaded.
+```

--- a/plugins/zip-extractor/package.json
+++ b/plugins/zip-extractor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@flatfile/plugin-zip-extractor",
   "version": "0.4.4",
+  "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/zip-extractor",
   "description": "A plugin for unzipping zip files and uploading content back in Flatfile.",
   "registryMetadata": {
     "category": "extractors"
@@ -18,7 +19,10 @@
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
     "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand"
   },
-  "keywords": [],
+  "keywords": [
+    "flatfile-plugins",
+    "category-extractors"
+  ],
   "author": "Carl Brugger",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Adding readme content and package keywords to extractors plugins

## Tell code reviewer how and what to test:

Validate readme content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced parsing capabilities for various file types including JSON, PDF, Excel, XML, and ZIP through updated plugins.
  - Detailed documentation for each plugin, including usage examples, API calls, and supported file types.

- **Documentation**
  - Updated README files for `@flatfile/plugin-xlsx-extractor` with detailed information on purpose, supported file types, parameters, API calls, and usage instructions.
  - Revised `package.json` for `@flatfile/plugin-xlsx-extractor` to improve description and add relevant URLs and keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->