### PR TITLE
fix: GraphQL schema filtering

### DIFF
--- a/.changeset/kind-owls-collect.md
+++ b/.changeset/kind-owls-collect.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-graphql-schema': patch
+---
+
+This release fixes filtering of GraphQL objects by providing Sheet slugs

--- a/plugins/graphql-schema/src/generate.sheet.ts
+++ b/plugins/graphql-schema/src/generate.sheet.ts
@@ -9,8 +9,11 @@ export function generateSheets(
 ): Flatfile.SheetConfig[] {
   const sheets = graphQLObjects
     .map((object) => {
-      let sheetConfig =
-        sheetConfigArray?.find((config) => config.slug === object.name) || {}
+      const sheetConfig = sheetConfigArray?.find(
+        (config) => config.slug === object.name
+      )
+
+      if (sheetConfigArray?.length > 0 && !sheetConfig) return
 
       const fields = object.fields
         .map((field) => generateField(field, object.name))


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
This PR fixes filtering of GraphQL objects by providing Sheet slugs

## Tell code reviewer how and what to test:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
    - Enhanced the filtering capability in the GraphQL schema management by providing Sheet slugs.
    - Improved logic in the `generateSheets` function to handle cases where `sheetConfig` is not found in `sheetConfigArray`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->