### PR TITLE
fix: excel parser error handling

### DIFF
--- a/.changeset/khaki-needles-join.md
+++ b/.changeset/khaki-needles-join.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-xlsx-extractor': patch
+---
+
+This release reattempts to read XLSX files that may have emitted an error that could be handled.

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -38,7 +38,14 @@ export async function parseBuffer(
         'File is too large to parse. Try converting this file to CSV.'
       )
     }
-    throw e
+
+    // Try reading the file again without the 'WTF' option.
+    workbook = XLSX.read(buffer, {
+      type: 'buffer',
+      cellDates: true,
+      dense: true,
+      dateNF: options?.dateNF || undefined,
+    })
   }
 
   const sheetNames = Object.keys(workbook.Sheets)


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
SheetJS's `WTF` mode is turned on by default in the excel extractor to catch out-of-memory errors. Without it on, SheetJS returns `undefined`. However SheetJS only intends `WTF` to be used for debugging as SheetJS can handle most errors.

## Tell code reviewer how and what to test:

Closes https://github.com/FlatFilers/support-triage/issues/1185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of large XLSX files to prevent errors during file parsing.
	- Patched the XLSX extractor plugin to reattempt reading files that initially fail due to recoverable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->