### PR TITLE
feat: Create Workbooks in Defined Order

### DIFF
--- a/.changeset/popular-swans-fix.md
+++ b/.changeset/popular-swans-fix.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-space-configure': patch
+---
+
+Updates workbook creation to cronologically follow the configured order.

--- a/plugins/space-configure/src/space.configure.ts
+++ b/plugins/space-configure/src/space.configure.ts
@@ -34,7 +34,7 @@ export function configureSpace(
       jobHandler('space:configure', async (event, tick) => {
         const { spaceId, environmentId } = event.context
         const config = typeof setup === 'function' ? await setup(event) : setup
-        let workbookIds: string[]
+        let workbookIds: string[] = []
         for (let i = 0; i < config.workbooks.length; i++) {
           const workbook = await api.workbooks.create({
             spaceId,

--- a/plugins/space-configure/src/space.configure.ts
+++ b/plugins/space-configure/src/space.configure.ts
@@ -34,17 +34,16 @@ export function configureSpace(
       jobHandler('space:configure', async (event, tick) => {
         const { spaceId, environmentId } = event.context
         const config = typeof setup === 'function' ? await setup(event) : setup
-        const workbookIds = await Promise.all(
-          config.workbooks.map(async (workbookConfig) => {
-            const workbook = await api.workbooks.create({
-              spaceId,
-              environmentId,
-              name: 'Workbook',
-              ...workbookConfig,
-            })
-            return workbook.data.id
+        let workbookIds: string[]
+        for (let i = 0; i < config.workbooks.length; i++) {
+          const workbook = await api.workbooks.create({
+            spaceId,
+            environmentId,
+            name: 'Workbook',
+            ...config.workbooks[i],
           })
-        )
+          workbookIds.push(workbook.data.id)
+        }
         await tick(50, 'Workbook created')
 
         await api.spaces.update(spaceId, {


### PR DESCRIPTION
- This is part of the solution for https://github.com/FlatFilers/support-triage/issues/1176
  - Related to this Platform PR - https://github.com/FlatFilers/Platform/pull/7243
- Instead of attempting to create all workbooks at the same time asynchronously, create the workbooks in the order in which they are defined by users when using the space-configure plugin
  - This change will allow the backend to keep the workbooks ordered the way the customer has defined them which will allow the customer to determine the order of the workbooks on the spaces sidebar (if they want to override the default alphabetical order)

## Please explain how to summarize this PR for the Changelog:

- Now creates workbooks chronologically the order in which they are specified when using the space-configure plugin

## Tell code reviewer how and what to test:

- Using the space-configure plugin, create several workbooks and make sure that their order specified is maintained in the workbook db pk and created_at fields


<details>
<summary>Example Usage</summary>

```ts
import type { FlatfileListener } from "@flatfile/listener";
import { configureSpace } from "@flatfile/plugin-space-configure";
import {
  adjectives,
  Config,
  starWars,
  uniqueNamesGenerator,
} from "unique-names-generator";
import { getMonstersIncWb } from "./workbooks/monsters_inc";

const config: Config = {
  dictionaries: [adjectives, starWars],
  separator: "_",
  length: 2,
  style: "capital",
};

const workbook_suffix: string = uniqueNamesGenerator(config); // Han Solo

export default function (listener: FlatfileListener) {
  listener.use(
    configureSpace(
      {
       // Based on this ordering, the workbooks should be created chronologically B, then C, then A.
        workbooks: [
          getMonstersIncWb({ name: `B - Monsters Inc - ${workbook_suffix}` }),
          getMonstersIncWb({ name: `C - Monsters Inc - ${workbook_suffix}` }),
          getMonstersIncWb({ name: `A- Monsters Inc - ${workbook_suffix}` }),
        ],
      },
      async (event, workbookIds, tick) => {
        const { spaceId } = event.context;
        // Callback is invoked once the Space and Workbooks are fully configured.
        // Job progress will be at 50% when the callback is invoked.
        tick(51, "Running callback!");

        // Do something...

        await tick(99, "Callback complete!");
      }
    )
  );
}

```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
    - Updated workbook creation method in space configuration to ensure workbooks are created in a specific order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->