### PR TITLE
chore: remove build from test workflow

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,8 +10,7 @@
             "dependsOn": ["^build:prod"]
         },
         "test": {
-            "inputs": ["**/*.spec.ts"],
-            "dependsOn": ["^build"]
+            "inputs": ["**/*.spec.ts"]
         }
     }
 }


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Remove `"dependsOn": ["^build"]` from turbo test config since GH workflow runs `build` prior to running `test`

## Tell code reviewer how and what to test:
