### PR TITLE
fix: jobHandler starting progress 10% -> 0%

### DIFF
--- a/.changeset/large-impalas-do.md
+++ b/.changeset/large-impalas-do.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-job-handler': patch
+---
+
+This release changes the jobHandler's starting progress from 10% to 1%

--- a/plugins/job-handler/src/job.handler.ts
+++ b/plugins/job-handler/src/job.handler.ts
@@ -47,7 +47,7 @@ export function jobHandler(
 
       await api.jobs.ack(jobId, {
         info: 'Accepted',
-        progress: 10,
+        progress: 0,
       })
 
       const tick = async (progress: number, info?: string) => {


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

This PR changes the jobHandler to start the job progress at 0% rather than 10%.

## Tell code reviewer how and what to test:
