### PR TITLE
feat: provide a more instructive error message when miscalled from a workbook-level action

### DIFF
--- a/.changeset/unlucky-stingrays-lie.md
+++ b/.changeset/unlucky-stingrays-lie.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-dedupe': patch
+---
+
+This release provides a more instructive error message when the dedupe plugin is miscalled from a workbook-level action instead of a sheet-level action.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22527,14 +22527,14 @@
     },
     "plugins/autocast": {
       "name": "@flatfile/plugin-autocast",
-      "version": "0.8.2",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/hooks": "^1.4.1",
         "@flatfile/util-common": "^1.3.2"
       },
       "devDependencies": {
-        "@flatfile/plugin-record-hook": "^1.5.3",
+        "@flatfile/plugin-record-hook": "^1.6.0",
         "@flatfile/rollup-config": "0.1.1"
       },
       "engines": {
@@ -22543,7 +22543,7 @@
       "peerDependencies": {
         "@flatfile/api": "^1.8.9",
         "@flatfile/listener": "^1.0.1",
-        "@flatfile/plugin-record-hook": "^1.5.3"
+        "@flatfile/plugin-record-hook": "^1.6.0"
       }
     },
     "plugins/automap": {
@@ -22567,10 +22567,10 @@
     },
     "plugins/constraints": {
       "name": "@flatfile/plugin-constraints",
-      "version": "1.2.2",
+      "version": "2.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@flatfile/plugin-record-hook": "^1.5.3",
+        "@flatfile/plugin-record-hook": "^1.6.0",
         "@flatfile/rollup-config": "0.1.1"
       },
       "engines": {
@@ -22579,7 +22579,7 @@
       "peerDependencies": {
         "@flatfile/api": "^1.8.9",
         "@flatfile/listener": "^1.0.1",
-        "@flatfile/plugin-record-hook": "^1.5.3"
+        "@flatfile/plugin-record-hook": "^1.6.0"
       }
     },
     "plugins/dedupe": {
@@ -22696,7 +22696,7 @@
     },
     "plugins/job-handler": {
       "name": "@flatfile/plugin-job-handler",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-common": "^1.3.2"
@@ -22848,7 +22848,7 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "1.5.3",
+      "version": "1.6.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-common": "^1.3.2"

--- a/plugins/dedupe/README.md
+++ b/plugins/dedupe/README.md
@@ -1,6 +1,6 @@
 <!-- START_INFOCARD -->
 
-This plugin dedupes records in a sheet via a sheet level custom action.
+This plugin dedupes records in a Sheet via a Sheet-level action.
 
 **Event Type:**
 `listener.on('job:ready')`
@@ -55,17 +55,39 @@ npm i @flatfile/plugin-dedupe
 import { dedupePlugin } from "@flatfile/plugin-dedupe";
 ```
 
-```ts
-// ... inside the Sheet configuration
-"actions": [
-  {
-    "operation": "dedupe-email",
-    "mode": "background",
-    "label": "Dedupe emails",
-    "description": "Remove duplicate emails"
-  }
-]
-// ...
+```ts contactsSheet.ts
+import { Flatfile } from '@flatfile/api'
+
+export const contactsSheet: Flatfile.SheetConfig = {
+  name: 'Contacts',
+  slug: 'contacts',
+  fields: [
+    {
+      key: 'firstName',
+      type: 'string',
+      label: 'First Name',
+    },
+    {
+      key: 'lastName',
+      type: 'string',
+      label: 'Last Name',
+    },
+    {
+      key: 'email',
+      type: 'string',
+      label: 'Email',
+    }
+  ],
+  // Add a Sheet-level action here for the dedupe plugin
+  actions: [
+    {
+      operation: "dedupe-email",
+      mode: "background",
+      label: "Dedupe emails",
+      description: "Remove duplicate emails"
+    }
+  ]
+}
 ```
 
 ### JavaScript
@@ -75,7 +97,7 @@ import { dedupePlugin } from "@flatfile/plugin-dedupe";
 ```js listener.js
 // common usage
 // Keep the last record encountered (from top to bottom) based on the`email` field key.
-// Must have a Sheet level action specified with the operation name `dedupe-email`
+// Must have a Sheet-level action specified with the operation name `dedupe-email`
 listener.use(
   dedupePlugin("dedupe-email", {
     on: "email",
@@ -112,7 +134,7 @@ listener.use(
 ```ts listener.ts
 // common usage
 // Keep the last record encountered (from top to bottom) based on the`email` field key.
-// Must have a Sheet level action specified with the operation name `dedupe-email`
+// Must have a Sheet-level action specified with the operation name `dedupe-email`
 listener.use(
   dedupePlugin("dedupe-email", {
     on: "email",

--- a/plugins/dedupe/src/dedupe.plugin.ts
+++ b/plugins/dedupe/src/dedupe.plugin.ts
@@ -32,6 +32,10 @@ export const dedupe = async (
 ): Promise<void | Flatfile.JobCompleteDetails> => {
   const { sheetId, workbookId } = event.context
 
+  if (!sheetId) {
+    throw new Error('Dedupe must be called from a sheet-level action')
+  }
+
   await tick(0, 'Dedupe started')
   const coreKeepOptionSelected = ['first', 'last'].includes(opts.keep)
   if (coreKeepOptionSelected && opts.on === undefined) {


### PR DESCRIPTION
This PR provides a more instructive error message when the dedupe plugin is miscalled from a workbook-level action instead of a sheet-level action.