### PR TITLE
fix: response rejection

### DIFF
--- a/.changeset/plenty-singers-collect.md
+++ b/.changeset/plenty-singers-collect.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/util-response-rejection': patch
+---
+
+Ensures proper order when response rejection is used with a Record Hook

--- a/flatfilers/sandbox/src/index.ts
+++ b/flatfilers/sandbox/src/index.ts
@@ -1,9 +1,52 @@
 import type { FlatfileListener } from '@flatfile/listener'
-
-import { DelimiterExtractor } from '@flatfile/plugin-delimiter-extractor'
-import { ExcelExtractor } from '@flatfile/plugin-xlsx-extractor'
+import { bulkRecordHook } from '@flatfile/plugin-record-hook'
+import { configureSpace } from '@flatfile/plugin-space-configure'
+import { webhookEgress } from '@flatfile/plugin-webhook-egress'
+import { contactsSheet } from '../../playground/src/blueprints'
 
 export default async function (listener: FlatfileListener) {
-  listener.use(ExcelExtractor())
-  listener.use(DelimiterExtractor('.txt', { delimiter: ',' }))
+  listener.use(
+    bulkRecordHook(
+      'contacts',
+      (records, _event) => {
+        console.log('records', records.length)
+      },
+      { debug: true }
+    )
+  )
+
+  listener.use(
+    webhookEgress(
+      'workbook:submitActionFg',
+      'http://localhost:5678/reject-non-flatfile-emails'
+    )
+  )
+
+  listener.namespace(
+    ['space:getting-started'],
+    configureSpace(
+      {
+        workbooks: [
+          {
+            name: 'Playground',
+            sheets: [contactsSheet],
+            actions: [
+              {
+                operation: 'submitActionFg',
+                mode: 'foreground',
+                label: 'Submit data',
+                type: 'string',
+                description: 'Submit this data to a webhook.',
+                primary: true,
+              },
+            ],
+          },
+        ],
+      },
+      async (event, workbookIds, tick) => {
+        const { spaceId } = event.context
+        console.log('Space configured', { spaceId, workbookIds })
+      }
+    )
+  )
 }


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

This PR closes https://github.com/FlatFilers/support-triage/issues/1317.

When the response rejection utility is used in a listener that also has a recordHook and is configured with `deleteSubmitted: false`, a status field is added to the sheet to indicate with records are submitted vs rejected. When this field is updated it triggers the recordHook to run, which in turn wipes out any messages set by the response rejection utility.

To by-pass this, this PR makes two `api.records.update` calls with a short timeout between them. The first call updates the status field values (triggering the recordHook). The second call only updates the message. The short timeout ensures that the second call happens after the recordHook has run.

## Tell code reviewer how and what to test:
Test listener:
```
import type { FlatfileListener } from '@flatfile/listener'
import { bulkRecordHook } from '@flatfile/plugin-record-hook'
import { webhookEgress } from '@flatfile/plugin-webhook-egress'

export default async function (listener: FlatfileListener) {
  listener.use(
    bulkRecordHook(
      'contacts',
      (records, _event) => {
        console.log('records', records.length)
      },
      { debug: true }
    )
  )

  listener.use(
    webhookEgress(
      'workbook:submitActionFg',
      'http://localhost:5678/reject-non-flatfile-emails' // Use https://github.com/carlbrugger/demo-partial-rejections
    )
  )
}
```
