### PR TITLE
Removed field.constraint.required from extractors.

### DIFF
--- a/.changeset/few-pots-move.md
+++ b/.changeset/few-pots-move.md
@@ -1,0 +1,12 @@
+---
+'@flatfile/plugin-delimiter-extractor': major
+'@flatfile/plugin-xlsx-extractor': major
+'@flatfile/util-extractor': major
+---
+
+Removed the 'Required' field check from extractors and the subsequent field.constraints.required. 
+This is a breaking change if you are using this required field check in your implementation.
+
+Source sheets don't require the field.constraints.required.
+
+If you need to implement this functionality you can use a listener to add in the field.constraints.required to the specific fields you need.

--- a/.changeset/four-drinks-pump.md
+++ b/.changeset/four-drinks-pump.md
@@ -1,7 +1,0 @@
----
-'@flatfile/plugin-delimiter-extractor': minor
-'@flatfile/plugin-xlsx-extractor': minor
-'@flatfile/util-extractor': minor
----
-
-Removed field.required from the extractor plugins

--- a/.changeset/four-drinks-pump.md
+++ b/.changeset/four-drinks-pump.md
@@ -1,0 +1,7 @@
+---
+'@flatfile/plugin-delimiter-extractor': minor
+'@flatfile/plugin-xlsx-extractor': minor
+'@flatfile/util-extractor': minor
+---
+
+Removed field.required from the extractor plugins

--- a/package-lock.json
+++ b/package-lock.json
@@ -22719,7 +22719,7 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^1.0.1",
@@ -23094,7 +23094,7 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^1.0.1",
@@ -23110,7 +23110,7 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.5.17",
+      "version": "0.5.18",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^1.0.1",

--- a/plugins/delimiter-extractor/src/parser.spec.ts
+++ b/plugins/delimiter-extractor/src/parser.spec.ts
@@ -15,12 +15,6 @@ describe('parser', () => {
     expect(await parseBuffer(colonBasicBuffer, { delimiter: '#' })).toEqual({
       Sheet1: {
         headers: ['Code', 'Details', 'BranchName', 'Tenant'],
-        required: {
-          Code: true,
-          Details: false,
-          BranchName: false,
-          Tenant: false,
-        },
         data: [
           {
             Code: { value: 'Personal Care' },

--- a/plugins/delimiter-extractor/src/parser.ts
+++ b/plugins/delimiter-extractor/src/parser.ts
@@ -65,12 +65,6 @@ export async function parseBuffer(
     const columnHeaders = options?.headerSelectionEnabled ? letters : header
 
     const headers = prependNonUniqueHeaderColumns(columnHeaders)
-    const required: Record<string, boolean> = {}
-    header.forEach((item) => {
-      const key = item.replace('*', '').trim()
-      const hasAsterisk = item.includes('*')
-      required[key] = hasAsterisk
-    })
 
     const data: Flatfile.RecordData[] = rows
       .filter((row) => !Object.values(row).every(isNullOrWhitespace))
@@ -93,7 +87,6 @@ export async function parseBuffer(
     return {
       [sheetName]: {
         headers,
-        required,
         data,
         metadata,
       },

--- a/plugins/xlsx-extractor/src/parser.spec.ts
+++ b/plugins/xlsx-extractor/src/parser.spec.ts
@@ -14,7 +14,6 @@ describe('parser', () => {
   test('Excel to WorkbookCapture', async () => {
     expect(capture.Departments).toEqual({
       headers: ['Code', 'Details', 'BranchName', 'Tenant'],
-      required: { Code: true, Details: false, BranchName: true, Tenant: true },
       data: [
         {
           Code: { value: 'Personal Care' },
@@ -90,71 +89,6 @@ describe('parser', () => {
         'Rebates_11',
         'Purchases_11',
       ])
-    })
-
-    test('required columns are marked', () => {
-      expect(capture['Departments'].required).toEqual({
-        Code: true,
-        Details: false,
-        BranchName: true,
-        Tenant: true,
-      })
-      expect(capture['Clients'].required).toEqual({
-        Id: true,
-        FirstName: true,
-        LastName: true,
-        Salutation: false,
-        Address: false,
-        'Suite Number': false,
-        City: false,
-        Province: false,
-        Country: false,
-        PostalCode: false,
-        MainPhoneNumber: false,
-        PersonalPhoneNumber: false,
-        OtherPhoneNumber: false,
-        FaxNumber: false,
-        EmailAddress: false,
-        Password: false,
-        DateOfBirth: false,
-        Gender: false,
-        Remarks: false,
-        HealthCardNumber: false,
-        CostCentreNumber: false,
-        Timezone: false,
-        preferred_language: false,
-        BranchName: true,
-        Tenant: true,
-        'referral source': false,
-      })
-      expect(capture['Rebates-Purchases'].required).toEqual({
-        Name: true,
-        Group: true,
-        Rebates: false,
-        Purchases: false,
-        Rebates_1: false,
-        Purchases_1: false,
-        Rebates_2: false,
-        Purchases_2: false,
-        Rebates_3: false,
-        Purchases_3: false,
-        Rebates_4: false,
-        Purchases_4: false,
-        Rebates_5: false,
-        Purchases_5: false,
-        Rebates_6: false,
-        Purchases_6: false,
-        Rebates_7: false,
-        Purchases_7: false,
-        Rebates_8: false,
-        Purchases_8: false,
-        Rebates_9: false,
-        Purchases_9: false,
-        Rebates_10: false,
-        Purchases_10: false,
-        Rebates_11: false,
-        Purchases_11: false,
-      })
     })
   })
 })

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -152,12 +152,6 @@ async function convertSheet({
   const columnHeaders = headerSelectionEnabled ? columnKeys : header
   const excelHeader = toExcelHeader(columnHeaders, columnKeys)
   const headers = prependNonUniqueHeaderColumns(excelHeader)
-  const required = Object.fromEntries(
-    Object.entries(excelHeader).map(([key, value]) => [
-      headers[key],
-      value?.toString().includes('*') ?? false,
-    ])
-  )
 
   const data = rows.map((row) =>
     mapValues(
@@ -174,7 +168,6 @@ async function convertSheet({
 
   return {
     headers: Object.values(headers).filter(Boolean),
-    required,
     data,
     metadata,
   }

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -190,22 +190,20 @@ function getWorkbookConfig(
 
 function getSheetConfig(
   name: string,
-  { headers, required, descriptions }: SheetCapture
+  { headers, descriptions }: SheetCapture
 ): Flatfile.SheetConfig {
   return {
     name,
     slug: slugify(name),
-    fields: keysToFields({ keys: headers, required, descriptions }),
+    fields: keysToFields({ keys: headers, descriptions }),
   }
 }
 
 export function keysToFields({
   keys,
-  required = {},
   descriptions = {},
 }: {
   keys: string[]
-  required?: Record<string, boolean>
   descriptions?: Record<string, string>
 }): Flatfile.Property[] {
   let index = 0
@@ -235,7 +233,6 @@ export function keysToFields({
       label: key,
       description: descriptions?.[key] || '',
       type: 'string',
-      constraints: required?.[key] ? [{ type: 'required' }] : [],
     }))
 }
 
@@ -262,7 +259,6 @@ export type WorkbookCapture = Record<string, SheetCapture>
  */
 export type SheetCapture = {
   headers: string[]
-  required?: Record<string, boolean>
   descriptions?: Record<string, null | string> | null
   data: Flatfile.RecordData[]
   metadata?: { rowHeaders: number[] }


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
This removes the check for '*' for if the field should be required or not. Source sheets shouldn't be required

## Tell code reviewer how and what to test:
Upload an xlsx file with field name that has a * in it. The produces sheet.config.fields shouldnt have a constraint=required.
