### PR TITLE
fix: normalize extracted column keys

### DIFF
--- a/.changeset/sharp-wasps-happen.md
+++ b/.changeset/sharp-wasps-happen.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/util-extractor': minor
+---
+
+Normalizes extracted column keys

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -200,6 +200,10 @@ function getSheetConfig(
   }
 }
 
+function normalizeKey(key: string): string {
+  return key.trim().replace('%', '_PERCENT_').replace('$', '_DOLLAR_')
+}
+
 export function keysToFields({
   keys,
   descriptions = {},
@@ -230,7 +234,7 @@ export function keysToFields({
   return Object.entries(countOfKeys)
     .sort((a, b) => a[1].index - b[1].index)
     .map(([key, _]) => ({
-      key,
+      key: normalizeKey(key),
       label: key,
       description: descriptions?.[key] || '',
       type: 'string',

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -201,7 +201,7 @@ function getSheetConfig(
 }
 
 function normalizeKey(key: string): string {
-  return key.trim().replace('%', '_PERCENT_').replace('$', '_DOLLAR_')
+  return key.trim().replace(/%/g, '_PERCENT_').replace(/\$/g, '_DOLLAR_')
 }
 
 export function keysToFields({


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
We changed how we generate column keys from the extracted file to prevent name collisions after further normalization.

## Tell code reviewer how and what to test:
