### PR TITLE
fix: normalize extracted column keys

### DIFF
--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -201,7 +201,7 @@ function getSheetConfig(
 }
 
 function normalizeKey(key: string): string {
-  return key.trim().replace('%', '_PERCENT_').replace('$', '_DOLLAR_')
+  return key.trim().replace(/%/g, '_PERCENT_').replace(/\$/g, '_DOLLAR_')
 }
 
 function normalizeRecordKeys(record: Flatfile.RecordData): Flatfile.RecordData {

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -205,12 +205,10 @@ function normalizeKey(key: string): string {
 }
 
 function normalizeRecordKeys(record: Flatfile.RecordData): Flatfile.RecordData {
-  return Object.fromEntries(
-    Object.entries(record).map(([key, value]) => [
-      normalizeKey(key),
-      value,
-    ])
-  )
+  return Object.entries(record).reduce((acc, [key, value]) => {
+    acc[normalizeKey(key)] = value
+    return acc
+  }, {} as Flatfile.RecordData)
 }
 
 export function keysToFields({

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -200,6 +200,10 @@ function getSheetConfig(
   }
 }
 
+function normalizeKey(key: string): string {
+  return key.trim().replace('%', '_PERCENT_').replace('$', '_DOLLAR_')
+}
+
 export function keysToFields({
   keys,
   descriptions = {},
@@ -230,7 +234,7 @@ export function keysToFields({
   return Object.entries(countOfKeys)
     .sort((a, b) => a[1].index - b[1].index)
     .map(([key, _]) => ({
-      key,
+      key: normalizeKey(key),
       label: key,
       description: descriptions?.[key] || '',
       type: 'string',

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -105,7 +105,7 @@ export const Extractor = (
               continue
             }
             await asyncBatch(
-              capture[sheet.name].data,
+              capture[sheet.name].data.map(normalizeRecordKeys),
               async (chunk) => {
                 await api.records.insert(sheet.id, chunk, {
                   compressRequestBody: true,
@@ -202,6 +202,15 @@ function getSheetConfig(
 
 function normalizeKey(key: string): string {
   return key.trim().replace('%', '_PERCENT_').replace('$', '_DOLLAR_')
+}
+
+function normalizeRecordKeys(record: Flatfile.RecordData): Flatfile.RecordData {
+  return Object.fromEntries(
+    Object.entries(record).map(([key, value]) => [
+      normalizeKey(key),
+      value,
+    ])
+  )
 }
 
 export function keysToFields({

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -205,10 +205,13 @@ function normalizeKey(key: string): string {
 }
 
 function normalizeRecordKeys(record: Flatfile.RecordData): Flatfile.RecordData {
-  return Object.entries(record).reduce((acc, [key, value]) => {
-    acc[normalizeKey(key)] = value
-    return acc
-  }, {} as Flatfile.RecordData)
+  const normalizedRecord = {} as Flatfile.RecordData
+  for (const key in record) {
+    if (record.hasOwnProperty(key)) {
+      normalizedRecord[normalizeKey(key)] = record[key]
+    }
+  }
+  return normalizedRecord
 }
 
 export function keysToFields({


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
The previous change was normalizing the sheet field keys, but the records were still written with respect to unnormalized keys.

## Tell code reviewer how and what to test:
Columns with a % and $ should extract correctly.
