### PR TITLE
fix: null header extraction

### DIFF
--- a/.changeset/short-apples-flash.md
+++ b/.changeset/short-apples-flash.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-xlsx-extractor': patch
+---
+
+This release fixes record extraction in the presence of empty columns

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -127,13 +127,14 @@ async function convertSheet({
 
   const headerizer = Headerizer.create(headerDetectionOptions)
   const headerStream = Readable.from(extractValues(rows))
-  const { header, skip } = await headerizer.getHeaders(headerStream)
-  if (debug) {
-    console.log('Detected header:', header)
-  }
+  const { skip } = await headerizer.getHeaders(headerStream)
   const headerKey = Math.max(0, skip - 1)
   const columnKeys = Object.keys(rows[headerKey])
   const headerRowValues = Object.values(rows[headerKey])
+
+  if (debug) {
+    console.log('Detected header:', headerRowValues)
+  }
 
   if (!headerSelectionEnabled) rows.splice(0, skip)
 

--- a/plugins/xlsx-extractor/src/parser.ts
+++ b/plugins/xlsx-extractor/src/parser.ts
@@ -133,6 +133,7 @@ async function convertSheet({
   }
   const headerKey = Math.max(0, skip - 1)
   const columnKeys = Object.keys(rows[headerKey])
+  const headerRowValues = Object.values(rows[headerKey])
 
   if (!headerSelectionEnabled) rows.splice(0, skip)
 
@@ -149,7 +150,7 @@ async function convertSheet({
       result[keys[index]] = value
       return result
     }, {})
-  const columnHeaders = headerSelectionEnabled ? columnKeys : header
+  const columnHeaders = headerSelectionEnabled ? columnKeys : headerRowValues
   const excelHeader = toExcelHeader(columnHeaders, columnKeys)
   const headers = prependNonUniqueHeaderColumns(excelHeader)
 


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
Fixes an issue where the presence of empty columns would shift the extracted cell values into other columns. While we remove null values for the purpose of header detection, we need to use the original data when constructing the actual headers.

## Tell code reviewer how and what to test:
An xlsx file with an empty column between filled columns should have the filled columns extracted correctly.
