### PR TITLE
Prevent `waitFor` from fulfilling early in util/testing

### DIFF
--- a/.changeset/purple-lizards-cross.md
+++ b/.changeset/purple-lizards-cross.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/utils-testing': minor
+---
+
+Fixed bug where `waitFor` promise was being fulfilled immediately. Changed `invocations` to store a log of FlatfileEvents and `invocationWatchers` to be compatible with the existing `matchEvent` method on Flatfile Listeners. Also exposed `invocationWatchers` to the public API.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,9 @@ jobs:
         with:
           node-version: 16
           cache: 'npm'
-  
+
       - name: Install dependencies
         run: npm ci
-
-      - name: Build
-        run: npm run build
 
       - name: Test
         run: npm run test

--- a/package-lock.json
+++ b/package-lock.json
@@ -22719,7 +22719,7 @@
     },
     "plugins/delimiter-extractor": {
       "name": "@flatfile/plugin-delimiter-extractor",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^2.1.1",
@@ -22830,7 +22830,7 @@
     },
     "plugins/json-extractor": {
       "name": "@flatfile/plugin-json-extractor",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^2.1.1"
@@ -23094,7 +23094,7 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^2.1.1",
@@ -23110,7 +23110,7 @@
     },
     "plugins/xml-extractor": {
       "name": "@flatfile/plugin-xml-extractor",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "clean": "find ./ '(' -name 'node_modules' -o -name 'dist' -o -name '.turbo' -o -name '.parcel-cache' ')' -type d -exec rm -rf {} +",
-    "test": "turbo test --concurrency=1",
+    "test": "turbo build && turbo test --concurrency=1",
     "build": "turbo build",
     "build:prod": "turbo build:prod",
     "build:clean": "npm run clean && npm i && turbo build",

--- a/test/toBePendingMatcher.ts
+++ b/test/toBePendingMatcher.ts
@@ -1,0 +1,38 @@
+import type { MatcherFunction } from 'expect'
+import * as util from 'node:util'
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBePending(): R
+    }
+    interface Expect {
+      toBePending<T>(): JestMatchers<T>
+    }
+  }
+}
+
+const toBePending: MatcherFunction<[recieved: unknown]> = (received) => {
+  const isPending = (promise: Promise<any>) =>
+    util.inspect(promise).includes('pending')
+
+  if (!(received instanceof Promise)) {
+    throw new TypeError('Actual value is not a promise!')
+  }
+
+  const pass = isPending(received)
+
+  if (pass) {
+    return {
+      message: () => `expected recieved promise not to be pending`,
+      pass: true,
+    }
+  } else {
+    return {
+      message: () => `expected recieved promise to be pending`,
+      pass: false,
+    }
+  }
+}
+
+expect.extend({ toBePending })

--- a/test/unit.cleanup.js
+++ b/test/unit.cleanup.js
@@ -1,5 +1,7 @@
 const getHeapSpaceStatistics = require('v8')
 
+jest.retryTimes(3, { logErrorsBeforeRetry: true })
+
 afterAll(() => {
   // cleanup mocks and modules and allow the GC to do its thing:
   jest.resetModules()

--- a/test/unit.cleanup.js
+++ b/test/unit.cleanup.js
@@ -1,7 +1,5 @@
 const getHeapSpaceStatistics = require('v8')
 
-jest.retryTimes(3, { logErrorsBeforeRetry: true })
-
 afterAll(() => {
   // cleanup mocks and modules and allow the GC to do its thing:
   jest.resetModules()

--- a/utils/testing/package.json
+++ b/utils/testing/package.json
@@ -14,7 +14,7 @@
     "build:watch": "parcel watch",
     "build:prod": "NODE_ENV=production parcel build",
     "check": "tsc ./**/*.ts --noEmit --esModuleInterop",
-    "test": "jest --passWithNoTests"
+    "test": "jest ./**/*.spec.ts --config=../../jest.config.js --runInBand --detectOpenHandles"
   },
   "author": "Carl Brugger",
   "repository": {

--- a/utils/testing/src/test.listener.spec.ts
+++ b/utils/testing/src/test.listener.spec.ts
@@ -100,6 +100,21 @@ describe('TestListener', () => {
       expect(promisedEvent).resolves.not.toThrow()
     })
 
+    it('accounts for past invocations matching the provided filters', async () => {
+      const initialPromise = listener.waitFor('example:ready', 1)
+      listener.dispatchEvent({ topic: 'example:ready' })
+      await currentEventLoopEnd()
+
+      const secondPromise = listener.waitFor('example:ready', 2)
+      listener.dispatchEvent({ topic: 'example:ready' })
+      await currentEventLoopEnd()
+
+      expect(initialPromise).not.toBePending()
+      expect(initialPromise).resolves.not.toThrow()
+      expect(secondPromise).not.toBePending()
+      expect(secondPromise).resolves.not.toThrow()
+    })
+
     it('does not resolve before an event matching the filter is dispatched', async () => {
       const promisedEvent = listener.waitFor('example:ready', 1, {
         sheet: 'someSpecificSheet',

--- a/utils/testing/src/test.listener.spec.ts
+++ b/utils/testing/src/test.listener.spec.ts
@@ -1,0 +1,137 @@
+import { TestListener } from './index'
+
+import '../../../test/toBePendingMatcher'
+
+const currentEventLoopEnd = () =>
+  new Promise((resolve) => setImmediate(resolve))
+
+describe('TestListener', () => {
+  let listener: TestListener
+
+  beforeEach(() => {
+    listener = new TestListener()
+  })
+
+  describe('#dispatchEvent', () => {
+    it('appends the event to the invocations map', async () => {
+      const events = [
+        { topic: 'first' },
+        { topic: 'second' },
+        { topic: 'second', payload: { job: 'somethingSpecific' } },
+      ]
+
+      await Promise.all(events.map((event) => listener.dispatchEvent(event)))
+
+      expect(listener.invocations.get('first')).toEqual([events[0]])
+      expect(listener.invocations.get('second')).toEqual([events[1], events[2]])
+      expect(listener.invocations.get('third')).toBe(undefined)
+    })
+
+    it('increments the `executedCount` on any matching watchers', async () => {
+      listener.waitFor('example:ready')
+      listener.waitFor('example:completed')
+
+      listener.dispatchEvent({ topic: 'example:ready' })
+      listener.dispatchEvent({ topic: 'example:ready' })
+      await currentEventLoopEnd()
+
+      expect(listener.invocationWatchers[0].executedCount).toBe(2)
+      expect(listener.invocationWatchers[1].executedCount).toBe(0)
+    })
+
+    it('fulfills pending promises that match the event', async () => {
+      const exampleReady = jest.fn()
+      const exampleCompleted = jest.fn()
+
+      listener.waitFor('example:ready').then(exampleReady)
+      listener
+        .waitFor('example:ready', 1, { sheet: 'specificSheet' })
+        .then(exampleReady)
+      listener.waitFor('example:completed').then(exampleCompleted)
+
+      await listener.dispatchEvent({ topic: 'example:ready' })
+
+      expect(exampleReady).toHaveBeenCalledTimes(1)
+      expect(exampleCompleted).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('#waitFor', () => {
+    it('adds a new watcher to the invocationWatchers list', async () => {
+      listener.waitFor('example:ready')
+      await currentEventLoopEnd()
+
+      expect(listener.invocationWatchers).toHaveLength(1)
+      expect(listener.invocationWatchers[0]).toMatchObject({
+        filter: { topic: 'example:ready' },
+        neededCount: 1,
+        executedCount: 0,
+        resolver: expect.any(Function),
+      })
+    })
+
+    it('resolves when the event is dispatched', async () => {
+      const promisedEvent = listener.waitFor('example:ready')
+
+      listener.dispatchEvent({ topic: 'example:ready' })
+      await currentEventLoopEnd()
+
+      expect(promisedEvent).not.toBePending()
+      expect(promisedEvent).resolves.not.toThrow()
+    })
+
+    it('does not resolve before the specified number of dispatches is met', async () => {
+      const promisedEvent = listener.waitFor('example:ready', 2)
+
+      listener.dispatchEvent({ topic: 'example:ready' })
+      await currentEventLoopEnd()
+
+      expect(promisedEvent).toBePending()
+    })
+
+    it('resolves when the specified number of dispatches is met', async () => {
+      const promisedEvent = listener.waitFor('example:ready', 2)
+
+      listener.dispatchEvent({ topic: 'example:ready' })
+      listener.dispatchEvent({ topic: 'example:ready' })
+      await currentEventLoopEnd()
+
+      expect(promisedEvent).not.toBePending()
+      expect(promisedEvent).resolves.not.toThrow()
+    })
+
+    it('does not resolve before an event matching the filter is dispatched', async () => {
+      const promisedEvent = listener.waitFor('example:ready', 1, {
+        sheet: 'someSpecificSheet',
+      })
+
+      listener.dispatchEvent({ topic: 'example:ready' })
+      await currentEventLoopEnd()
+
+      expect(promisedEvent).toBePending()
+    })
+
+    it('resolves when an event matching the filter is dispatched', async () => {
+      const promisedEvent = listener.waitFor('example:ready', 1, {
+        sheet: 'someSpecificSheet',
+      })
+
+      listener.dispatchEvent({
+        topic: 'example:ready',
+        payload: { sheet: 'someSpecificSheet' },
+      })
+      await currentEventLoopEnd()
+
+      expect(promisedEvent).not.toBePending()
+      expect(promisedEvent).resolves.not.toThrow()
+    })
+
+    it('supports passing a string for the job filter', async () => {
+      listener.waitFor('example:ready', 1, 'specificJob')
+
+      expect(listener.invocationWatchers[0].filter).toMatchObject({
+        job: 'specificJob',
+      })
+    })
+  })
+})

--- a/utils/testing/src/test.listener.ts
+++ b/utils/testing/src/test.listener.ts
@@ -69,14 +69,17 @@ export class TestListener extends FlatfileListener {
     }
 
     return new Promise((resolver) => {
+      const pastInvocations = this.invocations.get(topic) || []
+      const executedCount = pastInvocations.filter((event) =>
+        this.matchEvent(event, filter)
+      ).length
+
       this.invocationWatchers.push({
         filter,
         neededCount,
-        executedCount: 0,
+        executedCount,
         resolver,
       })
-
-      const pastInvocations = this.invocations.get(topic) || []
 
       for (const event of pastInvocations) {
         for (const watcher of this.invocationWatchers) {

--- a/utils/testing/src/test.listener.ts
+++ b/utils/testing/src/test.listener.ts
@@ -10,7 +10,7 @@ type invocationWatcher = {
   filter: EventFilter | undefined
   executedCount: number
   neededCount: number
-  resolver: (result: Number | PromiseLike<number>) => void
+  resolver: (result: number | PromiseLike<number>) => void
 }
 
 /**

--- a/utils/testing/src/test.listener.ts
+++ b/utils/testing/src/test.listener.ts
@@ -1,4 +1,17 @@
-import { FlatfileListener } from '@flatfile/listener'
+import type { Flatfile } from '@flatfile/api'
+
+import {
+  EventFilter,
+  FlatfileEvent,
+  FlatfileListener,
+} from '@flatfile/listener'
+
+type invocationWatcher = {
+  filter: EventFilter | undefined
+  executedCount: number
+  neededCount: number
+  resolver: (result: Number | PromiseLike<number>) => void
+}
 
 /**
  * TestListener class extending from FlatfileListener.
@@ -6,15 +19,10 @@ import { FlatfileListener } from '@flatfile/listener'
  */
 export class TestListener extends FlatfileListener {
   // Mapping of event names to their invocation counts
-  public invocations: Map<string, number> = new Map()
+  public invocations: Map<string, FlatfileEvent[]> = new Map()
 
   // List of watchers for event invocations
-  private invocationWatchers: [
-    number,
-    (num: number) => void,
-    string,
-    string,
-  ][] = []
+  public invocationWatchers: invocationWatcher[] = []
 
   /**
    * Overridden method from FlatfileListener to handle event dispatch.
@@ -22,17 +30,20 @@ export class TestListener extends FlatfileListener {
    * @param event The event being dispatched
    */
   async dispatchEvent(event: any): Promise<void> {
-    const currentCount = this.invocations.get(event.topic) || 0
-    this.invocations.set(event.topic, currentCount + 1)
-
     await super.dispatchEvent(event)
 
-    for (let [count, resolver, eventName, job] of this.invocationWatchers) {
-      const eventCount = this.invocations.get(eventName)
+    if (this.invocations.has(event.topic)) {
+      this.invocations.get(event.topic).push(event)
+    } else {
+      this.invocations.set(event.topic, [event])
+    }
 
-      if (event.topic === eventName && eventCount && eventCount >= count) {
-        if (!job || event.payload.job === job) {
-          resolver(eventCount)
+    for (const watcher of this.invocationWatchers) {
+      if (this.matchEvent(event, watcher.filter)) {
+        watcher.executedCount++
+
+        if (watcher.executedCount >= watcher.neededCount) {
+          watcher.resolver(watcher.executedCount)
         }
       }
     }
@@ -41,17 +52,41 @@ export class TestListener extends FlatfileListener {
   /**
    * Wait for a certain count of a specific event.
    *
-   * @param event The event to wait for
-   * @param count The count of the event
-   * @param job The job to wait for
+   * @param topic The event to wait for
+   * @param neededCount The count of the event
+   * @param filter The filter object to match. Supports passing a string for job name
    * @returns A promise that resolves when the count of the event has been reached
    */
-  waitFor(event: string, count: number = 1, job?: string): Promise<number> {
-    return new Promise((resolve) => {
-      this.invocationWatchers.push([count, resolve, event, job])
+  waitFor(
+    topic: string,
+    neededCount: number = 1,
+    filter?: EventFilter | string
+  ): Promise<number> {
+    if (typeof filter === 'string') {
+      filter = { topic, job: filter }
+    } else {
+      filter = { topic, ...filter }
+    }
 
-      if (this.invocations.get(event) >= count) {
-        resolve(this.invocations.get(event))
+    return new Promise((resolver) => {
+      this.invocationWatchers.push({
+        filter,
+        neededCount,
+        executedCount: 0,
+        resolver,
+      })
+
+      const pastInvocations = this.invocations.get(topic) || []
+
+      for (const event of pastInvocations) {
+        for (const watcher of this.invocationWatchers) {
+          if (
+            this.matchEvent(event, watcher.filter) &&
+            watcher.executedCount >= watcher.neededCount
+          ) {
+            watcher.resolver(watcher.executedCount)
+          }
+        }
       }
     })
   }
@@ -67,10 +102,9 @@ export class TestListener extends FlatfileListener {
    * Reset the state of the listener, clearing all event listeners and counts, and resetting all nodes.
    */
   reset(): void {
-    // @ts-ignore
     this.listeners = []
     this.invocations = new Map()
-    // @ts-ignore
-    this.nodes.forEach((n) => n.reset())
+    this.invocationWatchers = []
+    this.nodes = []
   }
 }


### PR DESCRIPTION
Fixed bug where `waitFor` promise was being fulfilled immediately. Changed `invocations` to store a log of FlatfileEvents and `invocationWatchers` to be compatible with the existing `matchEvent` method on Flatfile Listeners. Also exposed `invocationWatchers` to the public API.
