### PR TITLE
Fix/extractors

### DIFF
--- a/.changeset/red-humans-teach.md
+++ b/.changeset/red-humans-teach.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/util-extractor': patch
+---
+
+adds a small delay before writing and uses an IO optimized writer

--- a/.changeset/red-humans-teach.md
+++ b/.changeset/red-humans-teach.md
@@ -1,5 +1,0 @@
----
-'@flatfile/util-extractor': patch
----
-
-adds a small delay before writing and uses an IO optimized writer

--- a/package-lock.json
+++ b/package-lock.json
@@ -22670,7 +22670,7 @@
         "remeda": "^1.23.0"
       },
       "devDependencies": {
-        "@flatfile/utils-testing": "^0.1.6"
+        "@flatfile/utils-testing": "^0.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -22818,7 +22818,7 @@
       },
       "devDependencies": {
         "@flatfile/rollup-config": "0.1.1",
-        "@flatfile/utils-testing": "^0.1.6"
+        "@flatfile/utils-testing": "^0.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -23011,7 +23011,7 @@
       "devDependencies": {
         "@flatfile/api": "^1.8.9",
         "@flatfile/rollup-config": "0.1.1",
-        "@flatfile/utils-testing": "^0.1.6"
+        "@flatfile/utils-testing": "^0.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -23062,7 +23062,7 @@
       },
       "devDependencies": {
         "@flatfile/rollup-config": "0.1.1",
-        "@flatfile/utils-testing": "^0.1.6",
+        "@flatfile/utils-testing": "^0.2.0",
         "jest-fetch-mock": "^3.0.3"
       },
       "engines": {
@@ -23094,7 +23094,7 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^2.1.1",
@@ -23135,7 +23135,7 @@
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
-        "@flatfile/utils-testing": "^0.1.6",
+        "@flatfile/utils-testing": "^0.2.0",
         "express": "^4.18.2",
         "jest-fetch-mock": "^3.0.3"
       },
@@ -23175,7 +23175,7 @@
         "modern-async": "^2.0.0"
       },
       "devDependencies": {
-        "@flatfile/utils-testing": "^0.1.6",
+        "@flatfile/utils-testing": "^0.2.0",
         "@types/adm-zip": "^0.4.3"
       },
       "engines": {
@@ -23279,7 +23279,7 @@
     },
     "utils/testing": {
       "name": "@flatfile/utils-testing",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.8.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22722,7 +22722,7 @@
       "version": "2.1.1",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/util-extractor": "^2.1.1",
+        "@flatfile/util-extractor": "^2.1.2",
         "papaparse": "^5.4.1",
         "remeda": "^1.14.0"
       },
@@ -22833,7 +22833,7 @@
       "version": "0.8.1",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/util-extractor": "^2.1.1"
+        "@flatfile/util-extractor": "^2.1.2"
       },
       "devDependencies": {
         "@flatfile/rollup-config": "0.1.1"
@@ -23097,7 +23097,7 @@
       "version": "3.1.2",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/util-extractor": "^2.1.1",
+        "@flatfile/util-extractor": "^2.1.2",
         "remeda": "^1.14.0",
         "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
       },
@@ -23113,7 +23113,7 @@
       "version": "0.6.1",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/util-extractor": "^2.1.1",
+        "@flatfile/util-extractor": "^2.1.2",
         "remeda": "^1.24.0",
         "xml-json-format": "^1.0.8"
       },
@@ -23220,7 +23220,7 @@
     },
     "utils/extractor": {
       "name": "@flatfile/util-extractor",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-common": "^1.3.2",

--- a/plugins/delimiter-extractor/CHANGELOG.md
+++ b/plugins/delimiter-extractor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flatfile/plugin-delimiter-extractor
 
+## 2.1.2
+
+### Patch Changes
+
+- Update extractors to use common util
+
 ## 2.1.1
 
 ### Patch Changes

--- a/plugins/delimiter-extractor/package.json
+++ b/plugins/delimiter-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/plugin-delimiter-extractor",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/delimiter-extractor",
   "description": "A plugin for parsing .delimiter files in Flatfile.",
   "registryMetadata": {
@@ -32,7 +32,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/util-extractor": "^2.1.1",
+    "@flatfile/util-extractor": "^2.1.2",
     "papaparse": "^5.4.1",
     "remeda": "^1.14.0"
   },

--- a/plugins/json-extractor/CHANGELOG.md
+++ b/plugins/json-extractor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flatfile/plugin-json-extractor
 
+## 0.8.2
+
+### Patch Changes
+
+- Update extractors to use common util
+
 ## 0.8.1
 
 ### Patch Changes

--- a/plugins/json-extractor/package.json
+++ b/plugins/json-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/plugin-json-extractor",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/json-extractor",
   "description": "A plugin for parsing json files in Flatfile.",
   "registryMetadata": {
@@ -52,7 +52,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/util-extractor": "^2.1.1"
+    "@flatfile/util-extractor": "^2.1.2"
   },
   "devDependencies": {
     "@flatfile/rollup-config": "0.1.1"

--- a/plugins/xlsx-extractor/CHANGELOG.md
+++ b/plugins/xlsx-extractor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flatfile/plugin-xlsx-extractor
 
+## 3.1.3
+
+### Patch Changes
+
+- Update extractors to use common util
+
 ## 3.1.2
 
 ### Patch Changes

--- a/plugins/xlsx-extractor/package.json
+++ b/plugins/xlsx-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/plugin-xlsx-extractor",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/xlsx-extractor",
   "description": "A plugin for parsing xlsx files in Flatfile.",
   "registryMetadata": {
@@ -32,7 +32,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/util-extractor": "^2.1.1",
+    "@flatfile/util-extractor": "^2.1.2",
     "remeda": "^1.14.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
   },

--- a/plugins/xml-extractor/CHANGELOG.md
+++ b/plugins/xml-extractor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flatfile/plugin-dxp-config
 
+## 0.6.2
+
+### Patch Changes
+
+- Update extractors to use common util
+
 ## 0.6.1
 
 ### Patch Changes

--- a/plugins/xml-extractor/package.json
+++ b/plugins/xml-extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/plugin-xml-extractor",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A plugin for parsing .xml files in Flatfile.",
   "registryMetadata": {
     "category": "extractors"
@@ -31,7 +31,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/util-extractor": "^2.1.1",
+    "@flatfile/util-extractor": "^2.1.2",
     "remeda": "^1.24.0",
     "xml-json-format": "^1.0.8"
   },

--- a/utils/extractor/CHANGELOG.md
+++ b/utils/extractor/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @flatfile/plugin-extractor-utils
 
+## 2.1.2
+
+### Patch Changes
+
+- 78efe6c: adds a small delay before writing and uses an IO optimized writer
+
 ## 2.1.1
 
 ### Patch Changes

--- a/utils/extractor/package.json
+++ b/utils/extractor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/util-extractor",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/utils/extractor",
   "description": "A library containing common utilities and helpers for extractors.",
   "keywords": [

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -117,19 +117,6 @@ export const Extractor = (
                 )
               }
             )
-
-            await asyncBatch(
-              capture[sheet.name].data.map(normalizeRecordKeys),
-              async (chunk) => {
-                processedRecords += chunk.length
-                const progress = Math.min(
-                  99,
-                  Math.round(10 + (90 * processedRecords) / totalLength)
-                )
-                await tick(progress, 'Adding records to Sheets')
-              },
-              { chunkSize, parallel, debug }
-            )
           }
 
           // After all records are added, update the sheet metadata

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -1,7 +1,9 @@
 import api, { Flatfile } from '@flatfile/api'
 import type { FlatfileListener } from '@flatfile/listener'
-import { asyncBatch, createAllRecords, slugify } from '@flatfile/util-common'
+import { createAllRecords, slugify } from '@flatfile/util-common'
 import { getFileBuffer } from '@flatfile/util-file-buffer'
+
+const WORKBOOK_CREATION_DELAY = 3_000
 
 export const Extractor = (
   fileExt: string | RegExp,
@@ -100,7 +102,7 @@ export const Extractor = (
           )
 
           await new Promise((resolve) => {
-            setTimeout(resolve, 3_000)
+            setTimeout(resolve, WORKBOOK_CREATION_DELAY)
           })
 
           for (const sheet of workbook.sheets) {


### PR DESCRIPTION
This makes the extractor use the far more efficient `createAllRecords` utility over the `api.records.create`