### PR TITLE
Chore/upgrade util common package version

### DIFF
--- a/.changeset/bright-zebras-lie.md
+++ b/.changeset/bright-zebras-lie.md
@@ -1,0 +1,7 @@
+---
+'@flatfile/util-response-rejection': patch
+'@flatfile/plugin-xlsx-extractor': patch
+'@flatfile/util-extractor': patch
+---
+
+Updated util-common dependancy version to fix extraction error

--- a/package-lock.json
+++ b/package-lock.json
@@ -23055,7 +23055,8 @@
       }
     },
     "plugins/view-mapped": {
-      "version": "1.0.0",
+      "name": "@flatfile/plugin-view-mapped",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.9.7",
@@ -23124,7 +23125,7 @@
         "node": ">= 16"
       },
       "peerDependencies": {
-        "@flatfile/listener": "^1.0.1"
+        "@flatfile/listener": "^1.0.5"
       }
     },
     "plugins/xml-extractor": {
@@ -23242,7 +23243,7 @@
       "version": "2.1.2",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/util-common": "^1.3.2",
+        "@flatfile/util-common": "^1.3.7",
         "@flatfile/util-file-buffer": "^0.3.2"
       },
       "engines": {
@@ -23284,7 +23285,7 @@
       "version": "1.3.4",
       "license": "ISC",
       "dependencies": {
-        "@flatfile/util-common": "^1.3.2"
+        "@flatfile/util-common": "^1.3.7"
       },
       "devDependencies": {
         "@flatfile/rollup-config": "0.1.1"

--- a/plugins/xlsx-extractor/package.json
+++ b/plugins/xlsx-extractor/package.json
@@ -37,6 +37,6 @@
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
   },
   "peerDependencies": {
-    "@flatfile/listener": "^1.0.1"
+    "@flatfile/listener": "^1.0.5"
   }
 }

--- a/utils/extractor/package.json
+++ b/utils/extractor/package.json
@@ -29,7 +29,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/util-common": "^1.3.2",
+    "@flatfile/util-common": "^1.3.7",
     "@flatfile/util-file-buffer": "^0.3.2"
   },
   "peerDependencies": {

--- a/utils/response-rejection/package.json
+++ b/utils/response-rejection/package.json
@@ -51,7 +51,7 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@flatfile/util-common": "^1.3.2"
+    "@flatfile/util-common": "^1.3.7"
   },
   "peerDependencies": {
     "@flatfile/api": "^1.8.9"


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
Updated util-common dependency version to to fix excel extractor issue with previous versions.
 
## Tell code reviewer how and what to test:

remove package-lock.json and node_modules from plugin testing and do a `npm i` then test an excel upload. It should pass. 
Make sure util-common package is 1.3.7 
