### PR TITLE
fix:non-string values

### DIFF
--- a/.changeset/wise-zoos-smoke.md
+++ b/.changeset/wise-zoos-smoke.md
@@ -1,0 +1,6 @@
+---
+'@flatfile/plugin-xlsx-extractor': patch
+'@flatfile/util-extractor': patch
+---
+
+This release fixes an issue when using `raw` or `rawNumbers` with non-string values in the header row.

--- a/plugins/xlsx-extractor/src/utils.ts
+++ b/plugins/xlsx-extractor/src/utils.ts
@@ -6,7 +6,8 @@ export function prependNonUniqueHeaderColumns(
 
   for (const [key, value] of Object.entries(record)) {
     const newValue = value ? value : 'empty'
-    const cleanValue = newValue.replace('*', '')
+    const cleanValue =
+      typeof newValue === 'string' ? newValue.replace('*', '') : newValue
 
     if (cleanValue && counts[cleanValue]) {
       result[key] = `${cleanValue}_${counts[cleanValue]}`

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -237,6 +237,9 @@ export function keysToFields({
     { count: number; index: number; metadata?: { fieldRef: string } }
   > = keys.reduce((acc, key) => {
     if (!key) key = ''
+    if (typeof key !== 'string') {
+      key = String(key)
+    }
     key = key.trim()
     if (key === '') {
       key = 'empty'


### PR DESCRIPTION
This PR closes https://github.com/FlatFilers/support-triage/issues/1583

For testing, create an excel sheet that has non-string values (date/integer) formatted as the appropriate non-string type in the header row. Uploading the file should not fail file extraction. This PR converts those non-string values to string.

Listener:
```
import type { FlatfileListener } from '@flatfile/listener'
import { ExcelExtractor } from '@flatfile/plugin-xlsx-extractor'

export default async function (listener: FlatfileListener) {
  listener.use(
    ExcelExtractor({
      rawNumbers: true,
      raw: true,
    })
  )
}
```