### PR TITLE
fix: view-mapped plugin restrict to mapped sheet

### DIFF
--- a/.changeset/dull-apes-deny.md
+++ b/.changeset/dull-apes-deny.md
@@ -2,4 +2,4 @@
 '@flatfile/plugin-view-mapped': patch
 ---
 
-This release fixes a bug in the view-mapped plugin when multiple sheets have fields with the same key by limiting the view-mapped update to the sheet being mapped.
+This release fixes a bug in the view-mapped plugin when multiple sheets have fields with the same key by limiting the view-mapped update to the sheet being mapped. Additionally, the view-mapped plugin now only runs when the `trackChanges` setting in the workbook is enabled to prevent a race condition where the view-mapped plugin runs before hooks have completed.

--- a/.changeset/dull-apes-deny.md
+++ b/.changeset/dull-apes-deny.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-view-mapped': patch
+---
+
+This release fixes a bug in the view-mapped plugin when multiple sheets have fields with the same key by limiting the view-mapped update to the sheet being mapped.

--- a/plugins/view-mapped/src/view-mapped.ts
+++ b/plugins/view-mapped/src/view-mapped.ts
@@ -1,4 +1,4 @@
-import { Flatfile, FlatfileClient } from '@flatfile/api'
+import { type Flatfile, FlatfileClient } from '@flatfile/api'
 import type { FlatfileListener } from '@flatfile/listener'
 import { jobHandler } from '@flatfile/plugin-job-handler'
 import { logError } from '@flatfile/util-common'


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

This PR fixes a bug in the view-mapped plugin when multiple sheets have fields with the same key by limiting the view-mapped update to the sheet being mapped. Additionally, the view-mapped plugin now only runs when the `trackChanges` setting in the workbook is enabled to prevent a race condition where the view-mapped plugin runs before hooks have completed.

Closes https://github.com/FlatFilers/support-triage/issues/1696

## Tell code reviewer how and what to test:
