### PR TITLE
Mark the event as non optional for BulkRecordHook

### DIFF
--- a/.changeset/five-carrots-explain.md
+++ b/.changeset/five-carrots-explain.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-record-hook': major
+---
+
+Mark the event as non optional BulkRecordHook

--- a/plugins/record-hook/src/RecordHook.ts
+++ b/plugins/record-hook/src/RecordHook.ts
@@ -19,10 +19,7 @@ export interface RecordHookOptions {
 
 export const RecordHook = async (
   event: FlatfileEvent,
-  handler: (
-    record: FlatfileRecord,
-    event?: FlatfileEvent
-  ) => any | Promise<any>,
+  handler: (record: FlatfileRecord, event: FlatfileEvent) => any | Promise<any>,
   options: RecordHookOptions = {}
 ) => {
   const { concurrency = 10 } = options

--- a/plugins/record-hook/src/RecordHook.ts
+++ b/plugins/record-hook/src/RecordHook.ts
@@ -58,7 +58,7 @@ export const BulkRecordHook = async (
   event: FlatfileEvent,
   handler: (
     records: FlatfileRecord[],
-    event?: FlatfileEvent
+    event: FlatfileEvent
   ) => any | Promise<any>,
   options: BulkRecordHookOptions = {}
 ) => {

--- a/plugins/record-hook/src/record.hook.plugin.ts
+++ b/plugins/record-hook/src/record.hook.plugin.ts
@@ -7,7 +7,7 @@ export const recordHookPlugin = (
   sheetSlug: string,
   callback: (
     record: FlatfileRecord,
-    event?: FlatfileEvent
+    event: FlatfileEvent
   ) => any | Promise<any>,
   options: RecordHookOptions = {}
 ) => {
@@ -22,7 +22,7 @@ export const bulkRecordHookPlugin = (
   sheetSlug: string,
   callback: (
     records: FlatfileRecord[],
-    event?: FlatfileEvent
+    event: FlatfileEvent
   ) => any | Promise<any>,
   options: BulkRecordHookOptions = {}
 ) => {


### PR DESCRIPTION
This PR fixes the issue https://github.com/FlatFilers/configurator/issues/20

## Please explain how to summarize this PR for the Changelog:
Remove the `?` to make the `event` parameter non optional at `BulkRecordHook` function since we always have this information

## Tell code reviewer how and what to test:
The project should work the same way as before