### PR TITLE
feat: Use SpaceTemplate info for Namespace

### DIFF
--- a/.changeset/eleven-cameras-pretend.md
+++ b/.changeset/eleven-cameras-pretend.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-space-configure-from-template': minor
+---
+
+Bug fixes for space-configure-from-template-plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -3842,9 +3842,9 @@
       }
     },
     "node_modules/@flatfile/api": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.13.0.tgz",
-      "integrity": "sha512-fdE6d8L0jUeIxVHOCEZaZA8mcqZoxvEC0Bywn3RTf5v3w2KZWSJLLfWD7NxltiS9OxH3lvqOrqPofznv3OxD4w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@flatfile/api/-/api-1.15.0.tgz",
+      "integrity": "sha512-qOIqZYidzXulyTOdtglWVhboC++3uGa8+Ys6+o0XR+l7Jatmd36uJr3cVJ/7xSbq3rHYKNNGBNUA8fSd2Q0eDw==",
       "dependencies": {
         "@flatfile/cross-env-config": "0.0.4",
         "@types/pako": "2.0.1",
@@ -17882,7 +17882,6 @@
         "@flatfile/plugin-job-handler": "^0.8.1"
       },
       "devDependencies": {
-        "@flatfile/api": "^1.9.19",
         "@flatfile/bundler-config-tsup": "^0.2.0",
         "@flatfile/config-vitest": "^0.0.0",
         "@flatfile/utils-testing": "^0.5.0"
@@ -17891,7 +17890,7 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "@flatfile/api": "^1.9.19",
+        "@flatfile/api": "^1.15.0",
         "@flatfile/listener": "^1.1.0"
       }
     },

--- a/plugins/space-configure-from-template/package.json
+++ b/plugins/space-configure-from-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/plugin-space-configure-from-template",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/space-configure-from-template",
   "description": "A plugin for configuring a Flatfile Space from a Space Template.",
   "registryMetadata": {

--- a/plugins/space-configure-from-template/package.json
+++ b/plugins/space-configure-from-template/package.json
@@ -64,11 +64,10 @@
     "@flatfile/plugin-job-handler": "^0.8.1"
   },
   "peerDependencies": {
-    "@flatfile/api": "^1.9.19",
+    "@flatfile/api": "^1.15.0",
     "@flatfile/listener": "^1.1.0"
   },
   "devDependencies": {
-    "@flatfile/api": "^1.9.19",
     "@flatfile/bundler-config-tsup": "^0.2.0",
     "@flatfile/config-vitest": "^0.0.0",
     "@flatfile/utils-testing": "^0.5.0"

--- a/plugins/space-configure-from-template/package.json
+++ b/plugins/space-configure-from-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flatfile/plugin-space-configure-from-template",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "url": "https://github.com/FlatFilers/flatfile-plugins/tree/main/plugins/space-configure-from-template",
   "description": "A plugin for configuring a Flatfile Space from a Space Template.",
   "registryMetadata": {


### PR DESCRIPTION
- Get space template by appid and use the namespace from the space template instead of from the app
- Getting the app requires account level access, but agents only have environment level access
- Also fixed a bug with space update request body

## Please explain how to summarize this PR for the Changelog:

- Bug fixes for space-configure-from-template plugin
  - No longer relies on app access for namespace information
  - Fixed a space update request body bug

## Tell code reviewer how and what to test:
