### PR TITLE
Feat/automap extension

### DIFF
--- a/.changeset/fair-cobras-flow.md
+++ b/.changeset/fair-cobras-flow.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-automap': minor
+---
+
+Add onSuccess callback. New options to only map if there is no unmatched columns, change file name for untocuhed files and filename prefix/suffix

--- a/.changeset/fair-cobras-flow.md
+++ b/.changeset/fair-cobras-flow.md
@@ -2,4 +2,7 @@
 '@flatfile/plugin-automap': minor
 ---
 
-Add onSuccess callback. New options to only map if there is no unmatched columns, change file name for untocuhed files and filename prefix/suffix
+Add onSuccess callback. 
+Add new options to only map if there is no unmatched columns (none, both, only-source, only-target)
+Add options to change file name in success/failure case
+Add options to overwrite file name patterns

--- a/package-lock.json
+++ b/package-lock.json
@@ -17975,7 +17975,7 @@
     },
     "plugins/webhook-egress": {
       "name": "@flatfile/plugin-webhook-egress",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "ISC",
       "dependencies": {
         "@flatfile/plugin-job-handler": "^0.8.0",

--- a/plugins/automap/src/automap.plugin.ts
+++ b/plugins/automap/src/automap.plugin.ts
@@ -7,7 +7,8 @@ import { AutomapService } from './automap.service'
  * @param options - config options
  */
 export function automap(options: AutomapOptions) {
-  const automapper = new AutomapService(options)
+  const optionsDefaulted = defaultOptions(options)
+  const automapper = new AutomapService(optionsDefaulted)
 
   return (listener: FlatfileListener): void => {
     automapper.assignListeners(listener)
@@ -21,8 +22,17 @@ export function automap(options: AutomapOptions) {
  * @property {boolean} debug - show helpul messages useful for debugging (use intended for development).
  * @property {string} defaultTargetSheet - exact sheet name to import data to.
  * @property {RegExp} matchFilename - a regular expression to match specific files to perform automapping on.
- * @property {Function} onFailure - callback to be executed when plugin bails.
+ * @property {string} allColumnsMustBeMapped - specify if all columns must be mapped. Values: 'none', 'both', 'only-source', 'only-target'.
+ * @property {Function} onSuccess - callback to be executed when plugin succeeds.
+ * @property {Function} onFailure - callback to be executed when plugin fails.
  * @property {string} targetWorkbook - specify destination Workbook id or name.
+ * @property {boolean} disableFileNameUpdate - disable filename update on automap.
+ * @property {boolean} disableFileNameUpdateOnSuccess - disable filename update on success.
+ * @property {boolean} disableFileNameUpdateOnFailure - disable filename update on failure.
+ * @property {string} filenameOnCheck - filename on check mapping. Can use {{fileName}}.
+ * @property {string} filenameOnStart - filename on start mapping. Can use {{fileName}}, {{destinationSheetName}}.
+ * @property {string} filenameOnSuccess - filename on success mapping. Can use {{fileName}}, {{destinationSheetName}}.
+ * @property {string} filenameOnFailure - filename on failure mapping. Can use {{fileName}}.
  */
 export interface AutomapOptions {
   readonly accuracy: 'confident' | 'exact'
@@ -31,7 +41,48 @@ export interface AutomapOptions {
     | string
     | ((fileName?: string, event?: FlatfileEvent) => string | Promise<string>)
   readonly matchFilename?: RegExp
+  readonly allColumnsMustBeMapped?: 'none' | 'both' | 'only-source' | 'only-target'
+  readonly onSuccess?: (event: FlatfileEvent) => void
   readonly onFailure?: (event: FlatfileEvent) => void
   readonly targetWorkbook?: string
   readonly disableFileNameUpdate?: boolean
+  readonly disableFileNameUpdateOnSuccess?: boolean
+  readonly disableFileNameUpdateOnFailure?: boolean
+  readonly filenameOnCheck?: string
+  readonly filenameOnStart?: string
+  readonly filenameOnSuccess?: string
+  readonly filenameOnFailure?: string
 }
+
+export function defaultOptions(options: AutomapOptions): AutomapOptions {
+  const defaultedOptions = {
+    ...options,
+    accuracy: options.accuracy || 'confident',
+    allColumnsMustBeMapped: options.allColumnsMustBeMapped || 'none',
+    filenameOnCheck: options.filenameOnCheck || '⚡️ {{fileName}}',
+    filenameOnStart: options.filenameOnStart || '⚡️ {{fileName}} 🔁 {{destinationSheetName}}',
+    filenameOnSuccess: options.filenameOnSuccess || '⚡️ {{fileName}} 🔁 {{destinationSheetName}}',
+    filenameOnFailure: options.filenameOnFailure || '⚡️ {{fileName}} 🔁 {{destinationSheetName}}',
+  }
+
+  if(!defaultedOptions.filenameOnCheck.includes("{{fileName}}")) {
+    defaultedOptions.filenameOnCheck = defaultedOptions.filenameOnCheck + " {{fileName}}";
+  }
+
+  if(!defaultedOptions.filenameOnStart.includes("{{fileName}}")) {
+    defaultedOptions.filenameOnStart = defaultedOptions.filenameOnStart + " {{fileName}}";
+  }
+
+  if(!defaultedOptions.filenameOnSuccess.includes("{{fileName}}")) {
+    defaultedOptions.filenameOnSuccess = defaultedOptions.filenameOnSuccess + " {{fileName}}";
+  }
+
+  if(!defaultedOptions.filenameOnFailure.includes("{{fileName}}")) {
+    defaultedOptions.filenameOnFailure = defaultedOptions.filenameOnFailure + " {{fileName}}";
+  }
+  
+  return defaultedOptions
+  
+}
+
+


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

This PR adds a couple of new options for the automap plugin:

`onSuccess?: (event: FlatfileEvent) => void`

Option for callback in success case

`allColumnsMustBeMapped?: 'none' | 'both' | 'only-source' | 'only-target'`

Option that enables a check prior to the accuracy verification, to check if there are any unmatched columns (source or target sheet, none or both)

```
filenameOnCheck?: string
filenameOnStart?: string
filenameOnSuccess?: string
filenameOnFailure?: string
```

Options to override the file name on update

```
disableFileNameUpdateOnSuccess?: boolean
disableFileNameUpdateOnFailure?: boolean
```

Options to disbale updating the file name on success or failure of automap plugin

## Tell code reviewer how and what to test:

```
automap({
        accuracy: "confident",
        debug: false,
        defaultTargetSheet: "clients",
        matchFilename: /.*/,
        onFailure: (event: any) => {
          notify("Automap failed", "error", event.context.spaceId); 
        }
}),
```

These changes are backwards competible. So the above usage should result in the same behaviour as before.

```
automap({
        accuracy: "confident",
        allColumnsMustBeMapped: 'both',
        debug: false,
        defaultTargetSheet: "clients",
        filenameOnCheck: "Checking {{fileName}}",
        filenameOnStart: "Mapping {{fileName}} to {{destinationSheetName}}",
        filenameOnSuccess: "✅ [Automapped] {{fileName}} to {{destinationSheetName}}",
        filenameOnFailure: "❌ [Automap failed] {{fileName}} to {{destinationSheetName}}",
        matchFilename: /.*/,
        onSuccess: (event: any) => {
          console.log("success")
        },
        onFailure: (event: any) => {
          console.log("fail")
        }
}),
```

Setting those new options should result in:

1. Filename after extraction is changed to pattern in fileNameOnCheck
2. Filename after auto mapping is started should change to pattern in filenameOnStart
3. Filename after auto mapping succeeded should change to pattern in filenameOnSuccess
4. Filename after auto mapping failed should change to pattern in filenameOnFailure

Mapping should fail for files where either the source sheet or the destination sheet have unmatched columns

Console messages should be outputted in success and failure case.


