### PR TITLE
Features added to export-workbook plugin

### DIFF
--- a/.changeset/fluffy-pillows-call.md
+++ b/.changeset/fluffy-pillows-call.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-export-workbook': minor
+---
+
+Added options to adjust the origin and column headers

--- a/.changeset/fluffy-pillows-call.md
+++ b/.changeset/fluffy-pillows-call.md
@@ -1,5 +1,5 @@
 ---
-'@flatfile/plugin-export-workbook': minor
+'@flatfile/plugin-export-workbook': major
 ---
 
 Added options to adjust the origin and column headers

--- a/plugins/export-workbook/README.md
+++ b/plugins/export-workbook/README.md
@@ -44,7 +44,36 @@ Automatically download the file after exporting
 
 The `debug` parameter lets you toggle on/off helpful debugging messages for development purposes.
 
+#### `sheetOptions` - `Record<string, ExportSheetOptions>` - (optional)
 
+A map of sheet slug to `ExportSheetOptions` instance providing sheet specific export options:
+
+- `skipColumnHeaders` - `boolean` - (optional) - allows omitting column headers
+- `origin` - `number` | `SheetAddress` - (optional) - allows offsetting the start of a sheet. The parameter is either a row number or an object with `column` and `row`.
+
+Usage: 
+
+```typescript
+listener.use(
+  exportWorkbookPlugin({
+    sheetOptions: {
+      SomeSheetSlug: {
+        // Start the sheet at 5
+        origin: 5,
+        // Omit column headers
+        skipColumnHeaders: true,
+      },
+      SomeOtherSheetSlug: {
+        // Start the sheet at row 10 column 2
+        origin: {row: 10, column: 2},
+      },
+    },
+  })
+```
+
+#### `columnNameTransformer` - `ColumnNameTransformerCallback` - (optional)
+
+A callback function allowing changing how column names appear in the workbook. The function accepts two arguments: `columnName` and `sheetSlug` and returns a new column name. 
 
 ## Usage
 

--- a/plugins/export-workbook/src/index.ts
+++ b/plugins/export-workbook/src/index.ts
@@ -2,7 +2,8 @@ import type { FlatfileEvent } from '@flatfile/listener'
 import type { TickFunction } from '@flatfile/plugin-job-handler'
 
 import { jobHandler } from '@flatfile/plugin-job-handler'
-import { PluginOptions, exportRecords } from './plugin'
+import { exportRecords } from './plugin'
+import { PluginOptions } from './options'
 
 /**
  * Export records plugin for Flatfile.

--- a/plugins/export-workbook/src/index.ts
+++ b/plugins/export-workbook/src/index.ts
@@ -3,7 +3,7 @@ import type { TickFunction } from '@flatfile/plugin-job-handler'
 
 import { jobHandler } from '@flatfile/plugin-job-handler'
 import { exportRecords } from './plugin'
-import { PluginOptions } from './options'
+import type { PluginOptions } from './options'
 
 /**
  * Export records plugin for Flatfile.

--- a/plugins/export-workbook/src/options.ts
+++ b/plugins/export-workbook/src/options.ts
@@ -7,8 +7,8 @@ import type { Flatfile } from '@flatfile/api'
  * @property {number} row - The row component
  */
 export interface SheetAddress {
-  column: number;
-  row: number;
+  column: number
+  row: number
 }
 
 /**
@@ -18,11 +18,14 @@ export interface SheetAddress {
  * @property {boolean} skipColumnHeaders - If true, do not include column row in output
  */
 export interface ExportSheetOptions {
-  origin?: number | SheetAddress;
-  skipColumnHeaders?: boolean;
+  origin?: number | SheetAddress
+  skipColumnHeaders?: boolean
 }
 
-export type ColumnNameTransformerCallback = (columnName: string, sheetSlug: string) => string;
+export type ColumnNameTransformerCallback = (
+  columnName: string,
+  sheetSlug: string
+) => string
 
 /**
  * Plugin config options.
@@ -45,6 +48,6 @@ export interface PluginOptions {
   readonly includeRecordIds?: boolean
   readonly autoDownload?: boolean
   readonly debug?: boolean
-  readonly sheetOptions?: Record<string, ExportSheetOptions>;
-  readonly columnNameTransformer?: ColumnNameTransformerCallback;
+  readonly sheetOptions?: Record<string, ExportSheetOptions>
+  readonly columnNameTransformer?: ColumnNameTransformerCallback
 }

--- a/plugins/export-workbook/src/options.ts
+++ b/plugins/export-workbook/src/options.ts
@@ -1,0 +1,50 @@
+import type { Flatfile } from '@flatfile/api'
+
+/**
+ * A sheet address.
+ *
+ * @property {number} column - The column component
+ * @property {number} row - The row component
+ */
+export interface SheetAddress {
+  column: number;
+  row: number;
+}
+
+/**
+ * Sheet specific options.
+ *
+ * @property {number | SheetAddress} origin - The sheet origin
+ * @property {boolean} skipColumnHeaders - If true, do not include column row in output
+ */
+export interface ExportSheetOptions {
+  origin?: number | SheetAddress;
+  skipColumnHeaders?: boolean;
+}
+
+export type ColumnNameTransformerCallback = (columnName: string, sheetSlug: string) => string;
+
+/**
+ * Plugin config options.
+ *
+ * @property {string} jobName - name of the job
+ * @property {string[]} excludedSheets - list of sheet names to exclude from the exported data.
+ * @property {string[]} excludeFields - list of field names to exclude from the exported data. This applies to all sheets.
+ * @property {Flatfile.Filter} recordFilter - filter to apply to the records before exporting.
+ * @property {boolean} includeRecordIds - include record ids in the exported data.
+ * @property {boolean} autoDownload - auto download the file after exporting
+ * @property {boolean} debug - show helpful messages useful for debugging (use intended for development).
+ * @property {Record<string, ExportSheetOptions>} sheetOptions - map of sheet slug to ExportSheetOptions.
+ * @property {ColumnNameTransformerCallback} columnNameTransformer - callback to transform column names.
+ */
+export interface PluginOptions {
+  readonly jobName?: string
+  readonly excludedSheets?: string[]
+  readonly excludeFields?: string[]
+  readonly recordFilter?: Flatfile.Filter
+  readonly includeRecordIds?: boolean
+  readonly autoDownload?: boolean
+  readonly debug?: boolean
+  readonly sheetOptions?: Record<string, ExportSheetOptions>;
+  readonly columnNameTransformer?: ColumnNameTransformerCallback;
+}

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -13,7 +13,6 @@ import {
   sanitize,
   sanitizeExcelSheetName,
 } from './utils'
-import { Comments } from 'xlsx'
 import { PluginOptions } from './options'
 
 const api = new FlatfileClient()
@@ -92,14 +91,14 @@ export const exportRecords = async (
                         const cell: XLSX.CellObject = {
                           t: 's',
                           v: Array.isArray(value) ? value.join(', ') : value,
-                          c: [] as Comments,
+                          c: [],
                         }
                         if (R.length(messages) > 0) {
                           cell.c = messages.map((m) => ({
                             a: 'Flatfile',
                             t: `[${m.type.toUpperCase()}]: ${m.message}`,
                             T: true,
-                          })) as Comments
+                          }))
                           cell.c.hidden = true
                         }
 
@@ -132,7 +131,7 @@ export const exportRecords = async (
           const emptyCell: XLSX.CellObject = {
             t: 's',
             v: '',
-            c: [] as Comments,
+            c: [],
           }
 
           results = [

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -13,18 +13,18 @@ import {
   sanitize,
   sanitizeExcelSheetName,
 } from './utils'
-import { PluginOptions } from './options'
+import type { PluginOptions } from './options'
 
 const api = new FlatfileClient()
 
-const LOG_NAME = '@flatfile/plugin-export-workbook'
+import { name as PACKAGE_NAME } from '../package.json'
 
 /**
  * Runs extractor and creates an `.xlsx` file with all Flatfile Workbook data.
  *
  * @param event - Flatfile event
  * @param options - plugin config options
- * @param tick
+ * @param tick - a function to update job progress
  */
 export const exportRecords = async (
   event: FlatfileEvent,
@@ -48,7 +48,7 @@ export const exportRecords = async (
         }, '')
       )
 
-      logInfo(LOG_NAME, `Sheets found in Flatfile workbook: ${meta}`)
+      logInfo(PACKAGE_NAME, `Sheets found in Flatfile workbook: ${meta}`)
     }
 
     const xlsxWorkbook = XLSX.utils.book_new()
@@ -56,7 +56,7 @@ export const exportRecords = async (
     for (const [sheetIndex, sheet] of sheets.entries()) {
       if (options.excludedSheets?.includes(sheet.config.slug)) {
         if (options.debug) {
-          logInfo(LOG_NAME, `Skipping sheet: ${sheet.name}`)
+          logInfo(PACKAGE_NAME, `Skipping sheet: ${sheet.name}`)
         }
         continue
       }
@@ -163,7 +163,7 @@ export const exportRecords = async (
         )
       } catch (_) {
         logError(
-          LOG_NAME,
+          PACKAGE_NAME,
           `Failed to fetch records for sheet with id: ${sheet.id}`
         )
 
@@ -180,7 +180,7 @@ export const exportRecords = async (
 
     if (xlsxWorkbook.SheetNames.length === 0) {
       if (options.debug) {
-        logError(LOG_NAME, 'No data to write to Excel file')
+        logError(PACKAGE_NAME, 'No data to write to Excel file')
       }
 
       throw new Error('No data to write to Excel file.')
@@ -193,10 +193,10 @@ export const exportRecords = async (
       await tick(80, 'Excel file written to disk')
 
       if (options.debug) {
-        logInfo(LOG_NAME, 'File written to disk')
+        logInfo(PACKAGE_NAME, 'File written to disk')
       }
     } catch (_) {
-      logError(LOG_NAME, 'Failed to write file to disk')
+      logError(PACKAGE_NAME, 'Failed to write file to disk')
 
       throw new Error('Failed writing the Excel file to disk.')
     }
@@ -220,18 +220,18 @@ export const exportRecords = async (
 
       if (options.debug) {
         logInfo(
-          LOG_NAME,
+          PACKAGE_NAME,
           `Excel document uploaded. View file at https://spaces.flatfile.com/space/${spaceId}/files?mode=export`
         )
       }
     } catch (_) {
-      logError(LOG_NAME, 'Failed to upload file')
+      logError(PACKAGE_NAME, 'Failed to upload file')
 
       throw new Error('Failed uploading Excel file to Flatfile.')
     }
 
     if (options.debug) {
-      logInfo(LOG_NAME, 'Done')
+      logInfo(PACKAGE_NAME, 'Done')
     }
 
     return options.autoDownload
@@ -261,7 +261,7 @@ export const exportRecords = async (
           },
         }
   } catch (error) {
-    logError(LOG_NAME, error)
+    logError(PACKAGE_NAME, error)
 
     throw new Error((error as Error).message)
   }

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -134,10 +134,16 @@ export const exportRecords = async (
             v: '',
             c: [] as Comments,
           }
+
           results = [
-            sheet.config.fields.map((field) => ({
-              [columnNameTransformer(field.key)]: emptyCell,
-            })),
+            [
+              Object.fromEntries(
+                sheet.config.fields.map((field) => [
+                  columnNameTransformer(field.key),
+                  emptyCell,
+                ])
+              ),
+            ],
           ]
         }
         const rows = results.flat()

--- a/plugins/export-workbook/src/utils.spec.ts
+++ b/plugins/export-workbook/src/utils.spec.ts
@@ -1,6 +1,6 @@
 import { createXLSXSheetOptions } from './utils'
-import { ExportSheetOptions } from './options'
-import { JSON2SheetOpts } from 'xlsx'
+import type { ExportSheetOptions } from './options'
+import type { JSON2SheetOpts } from 'xlsx'
 
 describe('createXLSXSheetOptions', () => {
   it.each([

--- a/plugins/export-workbook/src/utils.spec.ts
+++ b/plugins/export-workbook/src/utils.spec.ts
@@ -1,0 +1,23 @@
+import { createXLSXSheetOptions } from './utils'
+import { ExportSheetOptions } from './options'
+import { JSON2SheetOpts } from 'xlsx'
+
+describe('createXLSXSheetOptions', () => {
+  it.each([
+    [null, {}],
+    [undefined, {}],
+    [{}, {}],
+    [{ skipColumnHeaders: true }, { skipHeader: true }],
+    [{ skipColumnHeaders: false }, {}],
+    [
+      { origin: 123, skipColumnHeaders: true },
+      { origin: 123, skipHeader: true },
+    ],
+    [{ origin: { row: 1, column: 2 } }, { origin: { r: 1, c: 2 } }],
+  ])(
+    'createXLSXSheetOptions %o',
+    (options: ExportSheetOptions, expected: JSON2SheetOpts) => {
+      expect(createXLSXSheetOptions(options)).toEqual(expected)
+    }
+  )
+})

--- a/plugins/export-workbook/src/utils.ts
+++ b/plugins/export-workbook/src/utils.ts
@@ -72,7 +72,10 @@ export function createXLSXSheetOptions(
   if (sheetOptions?.origin) {
     if (typeof sheetOptions.origin === 'number') {
       options.origin = sheetOptions.origin
-    } else {
+    } else if (
+      'column' in sheetOptions.origin &&
+      'row' in sheetOptions.origin
+    ) {
       options.origin = {
         c: sheetOptions.origin.column,
         r: sheetOptions.origin.row,

--- a/plugins/export-workbook/src/utils.ts
+++ b/plugins/export-workbook/src/utils.ts
@@ -1,5 +1,5 @@
-import { ExportSheetOptions } from './options'
-import { JSON2SheetOpts } from 'xlsx'
+import type { ExportSheetOptions } from './options'
+import type { JSON2SheetOpts } from 'xlsx'
 
 export function sanitize(fileName: string): string {
   // List of invalid characters that are commonly not allowed in file names

--- a/plugins/export-workbook/src/utils.ts
+++ b/plugins/export-workbook/src/utils.ts
@@ -1,3 +1,6 @@
+import { ExportSheetOptions, SheetAddress } from './options'
+import { JSON2SheetOpts, OriginOption } from 'xlsx'
+
 export function sanitize(fileName: string): string {
   // List of invalid characters that are commonly not allowed in file names
   const invalidChars = /[\/\?%\*:|"<>]/g
@@ -54,4 +57,31 @@ export const genCyclicPattern = (length: number = 104): Array<string> => {
   }
 
   return alphaPattern
+}
+
+/**
+ * Convert sheetOptions to JSON2SheetOpts.
+ *
+ * @param sheetOptions Sheet options
+ */
+export function createXLSXSheetOptions(
+  sheetOptions?: ExportSheetOptions
+): JSON2SheetOpts {
+  const options: JSON2SheetOpts = {}
+
+  if (sheetOptions?.origin) {
+    if (typeof sheetOptions.origin === 'number') {
+      options.origin = sheetOptions.origin
+    } else {
+      options.origin = {
+        c: sheetOptions.origin.column,
+        r: sheetOptions.origin.row,
+      }
+    }
+  }
+
+  if (sheetOptions?.skipColumnHeaders) {
+    options.skipHeader = true
+  }
+  return options
 }

--- a/plugins/export-workbook/src/utils.ts
+++ b/plugins/export-workbook/src/utils.ts
@@ -1,5 +1,5 @@
-import { ExportSheetOptions, SheetAddress } from './options'
-import { JSON2SheetOpts, OriginOption } from 'xlsx'
+import { ExportSheetOptions } from './options'
+import { JSON2SheetOpts } from 'xlsx'
 
 export function sanitize(fileName: string): string {
   // List of invalid characters that are commonly not allowed in file names


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

New options were added to the `export-workbook` plugin options:
- `columnNameTransformer` is a callback function enabling users to transform column names before exporting workbook. The callback takes a column name and slug name and returns a string. 
- `sheetOptions` is map of slug name to `SheetOptions` object with these props:
  - `origin`  the starting point of the sheet (can either be a row number or full column, row coordinate)
  - `skipColumnHeaders` optionally not include column headers. I know its not relevant for our use case, but could be worth while for someone.


## Tell code reviewer how and what to test:

This was tested in the plugin sandbox. 

A second sheet was added:
```
export const companies: Flatfile.SheetConfig = {
  name: 'Companies',
  slug: 'companies',
  fields: [
    {
      key: 'name',
      type: 'string',
      label: 'Name',
      constraints: [
        { type: 'required' },
        { type: 'unique', config: { caseSensitive: false } },
      ],
    },
    {
      key: 'location',
      type: 'string',
      label: 'Location',
    },
  ],
}
```

`export-workbook` was installed like so:
```
exportWorkbookPlugin({
        debug: true,
        sheetOptions: {
          companies: {
            origin: {row: 10, column: 2},
          },
        },
        columnNameTransformer: (name, slug) => slug === 'contacts' ? name.toUpperCase() : name,
      })
    )
```

Here are the results of an export:

The companies export starts the data at row 10 and column 2, as specified by `origin`
![Screenshot 2025-02-27 at 8 16 07 AM](https://github.com/user-attachments/assets/fee223f2-4572-4819-8223-3a41911cbbf6)

The contacts export transforms the column names to upper case.
![Screenshot 2025-02-27 at 8 16 01 AM](https://github.com/user-attachments/assets/b3904f68-c215-4646-aa67-492bee12ea3d)
