### PR TITLE
added option to exclude messages from the downloaded workbook

### DIFF
--- a/.changeset/blue-mayflies-change.md
+++ b/.changeset/blue-mayflies-change.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-export-workbook': minor
+---
+
+Added option to export workbook without record messages

--- a/flatfilers/sandbox/src/index.ts
+++ b/flatfilers/sandbox/src/index.ts
@@ -6,7 +6,9 @@ import {
   dataChecklist,
   dataChecklistPlugin,
 } from '@flatfile/plugin-space-configure'
+import { viewMappedPlugin } from '@flatfile/plugin-view-mapped'
 import { contacts } from './sheets/contacts'
+import { exportWorkbookPlugin } from '@flatfile/plugin-export-workbook'
 
 export default async function (listener: FlatfileListener) {
   listener.use(
@@ -14,12 +16,17 @@ export default async function (listener: FlatfileListener) {
       'contacts',
       async (records: FlatfileRecord[], event: FlatfileEvent) => {
         // TODO: Add your logic here
+        records.map((record) => {
+          record.set('firstName', 'John')
+        })
         return records
       },
       { debug: true }
     )
   )
-  listener.use(dataChecklistPlugin())
+
+  listener.use(viewMappedPlugin({ keepRequiredFields: true }))
+  listener.use(exportWorkbookPlugin({ excludeMessages: false }))
   listener.use(
     configureSpace(
       {
@@ -29,7 +36,7 @@ export default async function (listener: FlatfileListener) {
             sheets: [contacts],
             actions: [
               {
-                operation: 'simpleSubmitAction',
+                operation: 'downloadWorkbook',
                 mode: 'foreground',
                 label: 'Submit data',
                 description: 'Action for handling data inside of onSubmit',

--- a/plugins/export-workbook/README.md
+++ b/plugins/export-workbook/README.md
@@ -28,6 +28,10 @@ An array of sheets to be excluded from the export
 
 An array of fields to be excluded from the export
 
+#### `excludeMessages` - `boolean` - (optional) 
+
+If true, messages on records will be excluded from the exported data.
+
 #### `recordFilter` - `Flatfile.Filter` - (optional) 
 
 Allows filtering exported records to `valid` or `error`. By default all records will be exported

--- a/plugins/export-workbook/src/options.ts
+++ b/plugins/export-workbook/src/options.ts
@@ -33,6 +33,7 @@ export type ColumnNameTransformerCallback = (
  * @property {string} jobName - name of the job
  * @property {string[]} excludedSheets - list of sheet names to exclude from the exported data.
  * @property {string[]} excludeFields - list of field names to exclude from the exported data. This applies to all sheets.
+ * @property {boolean} excludeMessages - exclude record messages from the exported data.
  * @property {Flatfile.Filter} recordFilter - filter to apply to the records before exporting.
  * @property {boolean} includeRecordIds - include record ids in the exported data.
  * @property {boolean} autoDownload - auto download the file after exporting
@@ -44,6 +45,7 @@ export interface PluginOptions {
   readonly jobName?: string
   readonly excludedSheets?: string[]
   readonly excludeFields?: string[]
+  readonly excludeMessages?: boolean
   readonly recordFilter?: Flatfile.Filter
   readonly includeRecordIds?: boolean
   readonly autoDownload?: boolean

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -93,7 +93,9 @@ export const exportRecords = async (
                           v: Array.isArray(value) ? value.join(', ') : value,
                           c: [],
                         }
-                        if (R.length(messages) > 0) {
+                        if (options.excludeMessages) {
+                          cell.c = []
+                        } else if (R.length(messages) > 0) {
                           cell.c = messages.map((m) => ({
                             a: 'Flatfile',
                             t: `[${m.type.toUpperCase()}]: ${m.message}`,


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
adds an option to the plugin that allows the user to choose to omit messages on records from the generated file
## Tell code reviewer how and what to test:
Test the following scenarios: 
`  listener.use(exportWorkbookPlugin())` - no option specified - this should download a file with messages on cells
`  listener.use(exportWorkbookPlugin({excludeMessages: true}))` - option set to true - this should download a file with no record hook messages on cells
`  listener.use(exportWorkbookPlugin({excludeMessages: false}))` - option set to false - this should download a file with messages on cells