### PR TITLE
Added logic to not create excel job if smart extractor is enabled

### DIFF
--- a/.changeset/pink-apricots-double.md
+++ b/.changeset/pink-apricots-double.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/util-extractor': minor
+---
+
+When smart extractor is enabled we won't create an excel extractor job because smart extractor handles excel files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -296,6 +296,7 @@
     "flatfilers/playground": {
       "name": "@private/playground",
       "version": "0.0.0",
+      "extraneous": true,
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.9.19",
@@ -313,6 +314,7 @@
       "dependencies": {
         "@flatfile/api": "^1.9.19",
         "@flatfile/listener": "^1.1.0",
+        "@flatfile/plugin-xlsx-extractor": "^4.0.0",
         "@flatfile/utils-debugger": "^0.0.6"
       },
       "devDependencies": {
@@ -4997,10 +4999,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@private/playground": {
-      "resolved": "flatfilers/playground",
-      "link": true
     },
     "node_modules/@private/sandbox": {
       "resolved": "flatfilers/sandbox",
@@ -17586,7 +17584,7 @@
     },
     "plugins/export-workbook": {
       "name": "@flatfile/plugin-export-workbook",
-      "version": "4.0.1",
+      "version": "5.0.0",
       "license": "ISC",
       "devDependencies": {
         "@flatfile/bundler-config-tsup": "^0.2.0",
@@ -17816,7 +17814,7 @@
     },
     "plugins/record-hook": {
       "name": "@flatfile/plugin-record-hook",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-common": "^1.6.0"
@@ -17959,7 +17957,7 @@
     },
     "plugins/view-mapped": {
       "name": "@flatfile/plugin-view-mapped",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/api": "^1.9.19",
@@ -18001,7 +17999,7 @@
     },
     "plugins/webhook-event-forwarder": {
       "name": "@flatfile/plugin-webhook-event-forwarder",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "ISC",
       "dependencies": {
         "cross-fetch": "^4.0.0"
@@ -18020,7 +18018,7 @@
     },
     "plugins/xlsx-extractor": {
       "name": "@flatfile/plugin-xlsx-extractor",
-      "version": "3.5.1",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
         "@flatfile/util-extractor": "^2.5.0",

--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -30,10 +30,10 @@ export const Extractor = (
       if (fileExt instanceof RegExp && !fileExt.test(file.name)) {
         return
       }
-      
+
       // If the extractor is excel, check if the smart extractor is enabled
       // If it is, we need to return early because the smart extractor will handle the extraction
-      if(extractorType === 'excel') {
+      if (extractorType === 'excel') {
         const { data: entitlements } = await api.entitlements.list({
           resourceId: spaceId,
         })
@@ -87,9 +87,8 @@ export const Extractor = (
           const sourceEditorEnabled = !!entitlements.find(
             (e) => e.key === 'sourceEditor'
           )
-        
-          const buffer = await getFileBuffer(event)
 
+          const buffer = await getFileBuffer(event)
 
           await tick(3, 'plugins.extraction.parseSheets')
           const capture = await parseBuffer(buffer, {


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:
The smart extractor feature is handling excel files when enabled. This circumvents the excel extractor from triggering if smart extractor is enabled.

## Tell code reviewer how and what to test:
Add smart extractor entitlement. Upload an excel file. The plugin shouldn't create a job for excel extraction
