### PR TITLE
export workbook filename option

### DIFF
--- a/.changeset/nine-bags-pump.md
+++ b/.changeset/nine-bags-pump.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-export-workbook': minor
+---
+
+This release adds an option to provided a file name

--- a/plugins/export-workbook/src/options.ts
+++ b/plugins/export-workbook/src/options.ts
@@ -37,6 +37,7 @@ export type ColumnNameTransformerCallback = (
  * @property {Flatfile.Filter} recordFilter - filter to apply to the records before exporting.
  * @property {boolean} includeRecordIds - include record ids in the exported data.
  * @property {boolean} autoDownload - auto download the file after exporting
+ * @property {string} filename - filename to use for the exported file.
  * @property {boolean} debug - show helpful messages useful for debugging (use intended for development).
  * @property {Record<string, ExportSheetOptions>} sheetOptions - map of sheet slug to ExportSheetOptions.
  * @property {ColumnNameTransformerCallback} columnNameTransformer - callback to transform column names.
@@ -49,6 +50,7 @@ export interface PluginOptions {
   readonly recordFilter?: Flatfile.Filter
   readonly includeRecordIds?: boolean
   readonly autoDownload?: boolean
+  readonly filename?: string
   readonly debug?: boolean
   readonly sheetOptions?: Record<string, ExportSheetOptions>
   readonly columnNameTransformer?: ColumnNameTransformerCallback

--- a/plugins/export-workbook/src/plugin.ts
+++ b/plugins/export-workbook/src/plugin.ts
@@ -177,7 +177,9 @@ export const exportRecords = async (
 
     // Lambdas only allow writing to /tmp directory
     const timestamp = new Date().toISOString()
-    const fileName = `${sanitizedName}-${timestamp}.xlsx`
+    const fileName = options.filename
+      ? `${options.filename}.xlsx`
+      : `${sanitizedName}-${timestamp}.xlsx`
     const filePath = path.join('/tmp', fileName)
 
     if (xlsxWorkbook.SheetNames.length === 0) {


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

This PR adds an option to provided a file name

## Tell code reviewer how and what to test:
```
listener.use(
  exportWorkbookPlugin({
    filename: "custom-file-name",
  }),
);
```