### PR TITLE
pass optional event to parseBuffer in extractor plugin

### DIFF
--- a/utils/extractor/src/index.ts
+++ b/utils/extractor/src/index.ts
@@ -1,5 +1,5 @@
 import { Flatfile, FlatfileClient } from '@flatfile/api'
-import type { FlatfileListener } from '@flatfile/listener'
+import type { FlatfileEvent, FlatfileListener } from '@flatfile/listener'
 import { createAllRecords, slugify } from '@flatfile/util-common'
 import { getFileBuffer } from '@flatfile/util-file-buffer'
 const api = new FlatfileClient()
@@ -11,7 +11,8 @@ export const Extractor = (
   extractorType: string,
   parseBuffer: (
     buffer: Buffer,
-    options: any
+    options: any,
+    event?: FlatfileEvent
   ) => WorkbookCapture | Promise<WorkbookCapture>,
   options?: Record<string, any>
 ) => {
@@ -97,7 +98,7 @@ export const Extractor = (
             fileExt: file.ext,
             headerSelectionEnabled,
             getHeaders,
-          })
+          }, event)
 
           await tick(5, 'plugins.extraction.createWorkbook')
           const workbook = await createWorkbook(


### PR DESCRIPTION
## Please explain how to summarize this PR for the Changelog:

Allows passing the event as an optional parameter to the parseBuffer parameter of the Extractor plugin. This will be used to fetch secrets dynamically in a custom parse implementation using the event.

## Tell code reviewer how and what to test:
