### PR TITLE
chore: add changeset for export-workbook column order fix

### DIFF
--- a/.changeset/export-workbook-column-order.md
+++ b/.changeset/export-workbook-column-order.md
@@ -1,0 +1,5 @@
+---
+'@flatfile/plugin-export-workbook': patch
+---
+
+Export columns in blueprint field order instead of arbitrary API key order


### PR DESCRIPTION
Adds the missing changeset for PR #876 (already merged) so the changesets CI can bump the version and publish to npm.